### PR TITLE
Allow passing options to @vitejs/plugin-vue

### DIFF
--- a/packages/storybook-builder-vite/README.md
+++ b/packages/storybook-builder-vite/README.md
@@ -85,6 +85,20 @@ module.exports = {
 };
 ```
 
+### Vue Customization
+
+When using this builder with VueJs, your `.storybook/main.js` (or equivalent)
+can contain a `vueOptions` object to pass custom options to
+[`@vitejs/plugin-vue`](https://github.com/vitejs/vite/tree/main/packages/plugin-vue#options):
+
+```javascript
+module.exports = {
+    vueOptions: {
+        refTransform: true,
+    },
+};
+```
+
 ## Note about working directory
 
 The builder will by default enable Vite's [server.fs.strict](https://vitejs.dev/config/#server-fs-strict)

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -5,7 +5,7 @@ const { mdxPlugin } = require('./mdx-plugin');
 const { sourceLoaderPlugin } = require('./source-loader-plugin');
 
 module.exports.pluginConfig = function pluginConfig(options, type) {
-    const { framework, svelteOptions } = options;
+    const { framework, svelteOptions, vueOptions } = options;
     const plugins = [
         codeGeneratorPlugin(options),
         mockCoreJs(),
@@ -16,7 +16,7 @@ module.exports.pluginConfig = function pluginConfig(options, type) {
     if (framework === 'vue' || framework === 'vue3') {
         try {
             const vuePlugin = require('@vitejs/plugin-vue');
-            plugins.push(vuePlugin());
+            plugins.push(vuePlugin(vueOptions ?? {}));
             plugins.push(require('./plugins/vue-docgen')());
         } catch (err) {
             if (err.code !== 'MODULE_NOT_FOUND') {


### PR DESCRIPTION
This PR allow @vitejs/plugin-vue options to be set.
Then we can now use https://github.com/vuejs/rfcs/discussions/369 with storybook.