### PR TITLE
Experiment with react-docgen

### DIFF
--- a/packages/example-react/stories/Button.stories.jsx
+++ b/packages/example-react/stories/Button.stories.jsx
@@ -4,6 +4,7 @@ export default {
     title: 'Example/Button',
     component: Button,
     argTypes: {
+        onClick: { action: 'clicked' },
         backgroundColor: { control: 'color' },
     },
 };

--- a/packages/example-react/stories/ButtonTypescript.stories.tsx
+++ b/packages/example-react/stories/ButtonTypescript.stories.tsx
@@ -1,0 +1,35 @@
+import { Button } from './ButtonTypescript';
+
+export default {
+    title: 'Example/ButtonTypescript',
+    component: Button,
+    argTypes: {
+        onClick: { action: 'clicked' },
+        backgroundColor: { control: 'color' },
+    },
+};
+
+const Template = (args) => <Button {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+    primary: true,
+    label: 'Button',
+};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+    label: 'Button',
+};
+
+export const Large = Template.bind({});
+Large.args = {
+    size: 'large',
+    label: 'Button',
+};
+
+export const Small = Template.bind({});
+Small.args = {
+    size: 'small',
+    label: 'Button',
+};

--- a/packages/example-react/stories/ButtonTypescript.tsx
+++ b/packages/example-react/stories/ButtonTypescript.tsx
@@ -1,0 +1,38 @@
+import './button.css';
+import type {Size} from './types';
+
+type Props = {
+    /** Is this the principal call to action on the page? */
+    primary: boolean;
+    /** What background color to use */
+     backgroundColor?: string;
+     /** How large should the button be? */
+     size: Size;
+     /** Button contents */
+     label: string,
+     /** Optional click handler */
+     onClick: (e: React.SyntheticEvent<HTMLButtonElement>) => void,
+}
+
+/**
+ * Primary UI component for user interaction
+ */
+export const Button = ({ primary = false, backgroundColor, size = 'medium', label, ...props }: Props) => {
+    const mode = primary
+        ? 'storybook-button--primary'
+        : 'storybook-button--secondary';
+    return (
+        <button
+            type="button"
+            className={[
+                'storybook-button',
+                `storybook-button--${size}`,
+                mode,
+            ].join(' ')}
+            style={backgroundColor && { backgroundColor }}
+            {...props}
+        >
+            {label}
+        </button>
+    );
+};

--- a/packages/example-react/stories/ButtonTypescript.tsx
+++ b/packages/example-react/stories/ButtonTypescript.tsx
@@ -5,7 +5,7 @@ type Props = {
     /** Is this the principal call to action on the page? */
     primary: boolean;
     /** What background color to use */
-     backgroundColor?: string;
+     backgroundColor?: 'red' | 'blue';
      /** How large should the button be? */
      size: Size;
      /** Button contents */

--- a/packages/example-react/stories/types.ts
+++ b/packages/example-react/stories/types.ts
@@ -1,0 +1,1 @@
+export type Size = 'small' | 'medium' | 'large';

--- a/packages/example-react/tsconfig.json
+++ b/packages/example-react/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "jsx": "preserve"
+    }
+}

--- a/packages/storybook-builder-vite/package.json
+++ b/packages/storybook-builder-vite/package.json
@@ -12,6 +12,7 @@
     },
     "homepage": "https://github.com/eirslett/storybook-builder-vite/#readme",
     "dependencies": {
+        "@ianvs/babel-plugin-react-docgen": "5.0.0-alpha.0",
         "@mdx-js/mdx": "^1.6.22",
         "@storybook/csf-tools": "^6.3.3",
         "@storybook/source-loader": "^6.3.12",

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -60,6 +60,14 @@ module.exports.pluginConfig = async function pluginConfig(options, type) {
             require('@vitejs/plugin-react')({
                 // Do not treat story files as HMR boundaries, storybook itself needs to handle them.
                 exclude: [/\.stories\.(t|j)sx?$/, /node_modules/],
+                babel: {
+                    plugins: [[
+                        require.resolve('@ianvs/babel-plugin-react-docgen'),
+                        {
+                            DOC_GEN_COLLECTION_NAME: 'STORYBOOK_REACT_CLASSES',
+                        },
+                    ]]
+                }
             })
         );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,6 +1935,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ianvs/babel-plugin-react-docgen@npm:5.0.0-alpha.0":
+  version: 5.0.0-alpha.0
+  resolution: "@ianvs/babel-plugin-react-docgen@npm:5.0.0-alpha.0"
+  dependencies:
+    ast-types: ^0.14.2
+    lodash: ^4.17.15
+    react-docgen: 6.0.0-alpha.0
+  checksum: e95d33d6c25d16cd1a2777e07127db1876d43623cb04152f32f0ec30554cd72ddd79a3d4866ed0c4db5bf9d9a6b0a6ee4d40fa44490f3cea2b1b8d07fcbf7bc4
+  languageName: node
+  linkType: hard
+
 "@istanbuljs/load-nyc-config@npm:^1.0.0":
   version: 1.1.0
   resolution: "@istanbuljs/load-nyc-config@npm:1.1.0"
@@ -12253,6 +12264,27 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-docgen@npm:6.0.0-alpha.0":
+  version: 6.0.0-alpha.0
+  resolution: "react-docgen@npm:6.0.0-alpha.0"
+  dependencies:
+    "@babel/core": ^7.7.5
+    "@babel/generator": ^7.12.11
+    "@babel/runtime": ^7.7.6
+    ast-types: ^0.14.2
+    commander: ^2.19.0
+    doctrine: ^3.0.0
+    estree-to-babel: ^3.1.0
+    neo-async: ^2.6.1
+    node-dir: ^0.1.10
+    resolve: ^1.17.0
+    strip-indent: ^3.0.0
+  bin:
+    react-docgen: bin/react-docgen.js
+  checksum: b1e7ad594a6191ca9e83d1d94e103db6d7e643ef69e9a5d7ca593f0f94e124bcbd48f89aaae8d4952b465781025c74fc7ee2dd7d433136e07a6f3e9529411416
+  languageName: node
+  linkType: hard
+
 "react-docgen@npm:^5.0.0":
   version: 5.4.0
   resolution: "react-docgen@npm:5.4.0"
@@ -12870,7 +12902,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2":
+"resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@npm:^1.17.0":
   version: 1.20.0
   resolution: "resolve@npm:1.20.0"
   dependencies:
@@ -12880,7 +12912,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.15.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.15.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
   version: 1.20.0
   resolution: "resolve@patch:resolve@npm%3A1.20.0#~builtin<compat/resolve>::version=1.20.0&hash=07638b"
   dependencies:
@@ -13647,6 +13679,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "storybook-builder-vite@workspace:packages/storybook-builder-vite"
   dependencies:
+    "@ianvs/babel-plugin-react-docgen": 5.0.0-alpha.0
     "@mdx-js/mdx": ^1.6.22
     "@storybook/csf-tools": ^6.3.3
     "@storybook/source-loader": ^6.3.12


### PR DESCRIPTION
This is a similar experiment to https://github.com/eirslett/storybook-builder-vite/pull/167, but using [`@ianvs/babel-plugin-react-docgen@5.0.0-alpha.0`](https://www.npmjs.com/package/@ianvs/babel-plugin-react-docgen) so we can try out the 6.0.0-alpha.0 version of react-docgen.  

A few things I notice, which @ewlsh also pointed out in https://github.com/eirslett/storybook-builder-vite/issues/2#issuecomment-997671695:

- Union types are not handled correctly, and are shown as `union`
- Use of `React.FC` is not handled correctly
- Imported types now work, but they are shown with their typename, rather than expanding out to the actual value.  I'm not sure what `react-codegen-typescript` does, but having the actual type seems nicer than the type alias name.
- Function signatures are shown as `signature`, which doesn't really help much.

![image](https://user-images.githubusercontent.com/4616705/147697488-a82e4d9d-e73a-4f58-98c1-d31552751715.png)

Despite these limitations, it might be worth thinking about moving forward in this direction to at least get _some_ kind of support, though.  Ideally, we'd give an option to also use something like `react-codegen-typescript`, but this seems like maybe a good start.