### PR TITLE
[examples] Update vite and vite plugins

### DIFF
--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -24,11 +24,12 @@
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "^6.5.0-alpha.49",
     "@storybook/test-runner": "^0.0.4",
+    "@vitejs/plugin-react": "^1.3.0",
     "http-server": "^14.1.0",
     "jest": "^27.5.1",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.5.4",
-    "vite": "2.9.0-beta.8",
+    "vite": "2.9.0",
     "wait-on": "^6.0.1"
   }
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -24,10 +24,11 @@
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "^6.5.0-alpha.49",
     "@storybook/test-runner": "^0.0.4",
+    "@vitejs/plugin-react": "^1.3.0",
     "http-server": "^14.1.0",
     "jest": "^27.5.1",
     "npm-run-all": "^4.1.5",
-    "vite": "2.9.0-beta.8",
+    "vite": "2.9.0",
     "wait-on": "^6.0.1"
   }
 }

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -31,7 +31,7 @@
     "npm-run-all": "^4.1.5",
     "svelte-preprocess": "^4.10.4",
     "typescript": "^4.5.5",
-    "vite": "2.9.0-beta.8",
+    "vite": "2.9.0",
     "wait-on": "^6.0.1"
   }
 }

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "vue": "^3.2.0"
+    "vue": "^3.2.25"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.5.0-alpha.49",
@@ -22,11 +22,11 @@
     "@storybook/builder-vite": "workspace:*",
     "@storybook/test-runner": "^0.0.4",
     "@storybook/vue3": "^6.5.0-alpha.49",
-    "@vitejs/plugin-vue": "^1.10.2",
+    "@vitejs/plugin-vue": "^2.3.0",
     "http-server": "^14.1.0",
     "jest": "^27.5.1",
     "npm-run-all": "^4.1.5",
-    "vite": "2.9.0-beta.8",
+    "vite": "2.9.0",
     "wait-on": "^6.0.1"
   }
 }

--- a/examples/workspaces/packages/catalog/package.json
+++ b/examples/workspaces/packages/catalog/package.json
@@ -20,6 +20,6 @@
     "@storybook/addon-essentials": "^6.5.0-alpha.49",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "^6.5.0-alpha.49",
-    "vite": "2.9.0-beta.7"
+    "vite": "2.9.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/compat-data@npm:^7.17.7":
+  version: 7.17.7
+  resolution: "@babel/compat-data@npm:7.17.7"
+  checksum: bf13476676884ce9afc199747ff82f3bcd6d42a9cfb01ce91bdb762b83ea11ec619b6ec532d1a80469ab14f191f33b5d4b9f8796fa8be3bc728d42b0c5e737e3
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:7.12.9":
   version: 7.12.9
   resolution: "@babel/core@npm:7.12.9"
@@ -153,6 +160,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.17.8":
+  version: 7.17.8
+  resolution: "@babel/core@npm:7.17.8"
+  dependencies:
+    "@ampproject/remapping": ^2.1.0
+    "@babel/code-frame": ^7.16.7
+    "@babel/generator": ^7.17.7
+    "@babel/helper-compilation-targets": ^7.17.7
+    "@babel/helper-module-transforms": ^7.17.7
+    "@babel/helpers": ^7.17.8
+    "@babel/parser": ^7.17.8
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.17.3
+    "@babel/types": ^7.17.0
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    semver: ^6.3.0
+  checksum: 0e686b1be444d25494424065238931f2b3df908bf072b72bab973acfd6d27a481fc280c9cd8a3c6fe2c46beee50e0d2307468d8b15b64dc4036f025e75f6609d
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.12.5, @babel/generator@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/generator@npm:7.14.5"
@@ -183,6 +213,17 @@ __metadata:
     jsesc: ^2.5.1
     source-map: ^0.5.0
   checksum: ddf70e3489976018dfc2da8b9f43ec8c582cac2da681ed4a6227c53b26a9626223e4dca90098b3d3afe43bc67f20160856240e826c56b48e577f34a5a7e22b9f
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.17.7":
+  version: 7.17.7
+  resolution: "@babel/generator@npm:7.17.7"
+  dependencies:
+    "@babel/types": ^7.17.0
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: e7344b9b4559115f2754ecc2ae9508412ea6a8f617544cd3d3f17cabc727bd30630765f96c8a4ebc8901ded1492a3a6c23d695a4f1e8f3042f860b30c891985c
   languageName: node
   linkType: hard
 
@@ -253,6 +294,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 7238aaee78c011a42fb5ca92e5eff098752f7b314c2111d7bb9cdd58792fcab1b9c819b59f6a0851dc210dc09dc06b30d130a23982753e70eb3111bc65204842
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.17.7":
+  version: 7.17.7
+  resolution: "@babel/helper-compilation-targets@npm:7.17.7"
+  dependencies:
+    "@babel/compat-data": ^7.17.7
+    "@babel/helper-validator-option": ^7.16.7
+    browserslist: ^4.17.5
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 24bf851539d5ec8e73779304b5d1ad5b0be09a74459ecc7d9baee9a0fa38ad016e9eaf4b5704504ae8da32f91ce0e31857bbbd9686854caeffd38f58226d3760
   languageName: node
   linkType: hard
 
@@ -544,6 +599,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-transforms@npm:^7.17.7":
+  version: 7.17.7
+  resolution: "@babel/helper-module-transforms@npm:7.17.7"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.16.7
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/helper-simple-access": ^7.17.7
+    "@babel/helper-split-export-declaration": ^7.16.7
+    "@babel/helper-validator-identifier": ^7.16.7
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.17.3
+    "@babel/types": ^7.17.0
+  checksum: 0b8f023aa7ff82dc4864349d54c4557865ad8ba54d78f6d78a86b05ca40f65c2d60acb4a54c5c309e7a4356beb9a89b876e54af4b3c4801ad25f62ec3721f0ae
+  languageName: node
+  linkType: hard
+
 "@babel/helper-optimise-call-expression@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-optimise-call-expression@npm:7.14.5"
@@ -667,6 +738,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-simple-access@npm:^7.17.7":
+  version: 7.17.7
+  resolution: "@babel/helper-simple-access@npm:7.17.7"
+  dependencies:
+    "@babel/types": ^7.17.0
+  checksum: 58a9bfd054720024f6ff47fbb113c96061dc2bd31a5e5285756bd3c2e83918c6926900e00150d0fb175d899494fe7d69bf2a8b278c32ef6f6bea8d032e6a3831
+  languageName: node
+  linkType: hard
+
 "@babel/helper-skip-transparent-expression-wrappers@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.14.5"
@@ -783,6 +863,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.17.8":
+  version: 7.17.8
+  resolution: "@babel/helpers@npm:7.17.8"
+  dependencies:
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.17.3
+    "@babel/types": ^7.17.0
+  checksum: 463dad58119fefebf2d0201bfa53ec9607aa00356908895640fc07589747fb3c2e0dfee4019f3e8c9781e57c9aa5dff4c72ec8d1b031c4ed8349f90b6aefe99d
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/highlight@npm:7.14.5"
@@ -829,6 +920,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: bd828b933118354ecae482240e100205738b9d8bff06cf615493c470cad09198d8c024f3e28053f38f875f90d566a5994c19a4c0329bb0c126a994cb031e90e1
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.17.8":
+  version: 7.17.8
+  resolution: "@babel/parser@npm:7.17.8"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 1771808491982cc47baa888a997aef6b58308e3844c8c00f730f8fd97defe57d32cdbf46075cd49aaee310fa31f3d2c80a0d41b41a4ee0ff336ee09e2ff6c222
   languageName: node
   linkType: hard
 
@@ -1225,6 +1325,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 3a2ba87534b0f9ee70eba0754d2ae544825c25afd98efb8e42b41399e02de4cc5b1f70fc5ce444fb7a7e5b09972c289eed2f00917be5b88d67407f4cbde8e960
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/plugin-syntax-jsx@npm:7.16.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.16.7
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: cd9b0e53c50e8ddb0afaf0f42e0b221a94e4f59aee32a591364266a31195c48cac5fef288d02c1c935686bda982d2e0f1ed61cceb995fc9f6fb09ef5ebecdd2b
   languageName: node
   linkType: hard
 
@@ -1647,6 +1758,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-jsx-development@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/plugin-transform-react-jsx-development@npm:7.16.7"
+  dependencies:
+    "@babel/plugin-transform-react-jsx": ^7.16.7
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 697c71cb0ac9647a9b8c6f1aca99767cf06197f6c0b5d1f2e0c01f641e0706a380779f06836fdb941d3aa171f868091270fbe9fcfbfbcc2a24df5e60e04545e8
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-jsx-self@npm:^7.14.9":
   version: 7.14.9
   resolution: "@babel/plugin-transform-react-jsx-self@npm:7.14.9"
@@ -1658,6 +1780,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-jsx-self@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.16.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.16.7
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: cf1e408eedf99de3e49689473f329f0a45f1d8642536398570267f564a0da785a676045f042ca6e5d026bcee271127e3b2555fd84949fb7fc87f8ba4fefec34e
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-jsx-source@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/plugin-transform-react-jsx-source@npm:7.14.5"
@@ -1666,6 +1799,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: e7e7336bbd07d6c1a281bac1b242e8cb8172f3b1e1d9d214160ab220142fbefc5d79786d57bf197b18f4c694edfc7614dddae2f990adb4b7484146635b58dfe6
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx-source@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/plugin-transform-react-jsx-source@npm:7.16.7"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.16.7
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 722147fd37d8b5343ab88f611f0e05dd1e298ac981ec74797751689d4a3ed35a09af1d62dc81bf78efee922d8962aa0840a4fcf07f030434139e41012ade851d
   languageName: node
   linkType: hard
 
@@ -1696,6 +1840,21 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 833426a5d3f63ae8ae0d11a5966ddb26fe281c46695ecb1deab7aebc5a4ed3ecd3bcd49499cb5e355be46fa22dd012508f86b26a2962dc29660db1ec32705a2b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx@npm:^7.16.7, @babel/plugin-transform-react-jsx@npm:^7.17.3":
+  version: 7.17.3
+  resolution: "@babel/plugin-transform-react-jsx@npm:7.17.3"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.16.7
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/helper-plugin-utils": ^7.16.7
+    "@babel/plugin-syntax-jsx": ^7.16.7
+    "@babel/types": ^7.17.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7e33a3fb78a3b7352b56f48211160ae60dc3654bae314ea0352bfc179d10eaac789792ccb3701172388ec4e4dbdb94952cdf3386980f3af402d99ceadd91149b
   languageName: node
   linkType: hard
 
@@ -2789,6 +2948,16 @@ __metadata:
     estree-walker: ^2.0.1
     picomatch: ^2.2.2
   checksum: 498d67e7b48c707e3e0d9f7ddaa405833d77575b2d9607cd1914be40455ed534235e0512f9d046bf0e4ed1740e7816fd32ab1c673195e897c4fa180bcbfd7283
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@rollup/pluginutils@npm:4.2.0"
+  dependencies:
+    estree-walker: ^2.0.1
+    picomatch: ^2.2.2
+  checksum: 2e86d9bfb95919727bcba0bbbdbedc98e25a1e51fe3047f18ec6d85e0743d1c73e1c0de3f9fdbd2ff6b90c32f30d4b2706c9e794f3c2e7a80156980081558e2e
   languageName: node
   linkType: hard
 
@@ -4954,12 +5123,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-vue@npm:^1.10.2":
-  version: 1.10.2
-  resolution: "@vitejs/plugin-vue@npm:1.10.2"
+"@vitejs/plugin-react@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@vitejs/plugin-react@npm:1.3.0"
+  dependencies:
+    "@babel/core": ^7.17.8
+    "@babel/plugin-transform-react-jsx": ^7.17.3
+    "@babel/plugin-transform-react-jsx-development": ^7.16.7
+    "@babel/plugin-transform-react-jsx-self": ^7.16.7
+    "@babel/plugin-transform-react-jsx-source": ^7.16.7
+    "@rollup/pluginutils": ^4.2.0
+    react-refresh: ^0.11.0
+    resolve: ^1.22.0
+  checksum: 3af715b223f3115b271135909f372cd17d1d14a0c756d4b09df9d8ce3cc032e7f7fcb1c056becc62998a4c262c91aa7d6058ff496513c3c98852d1e6f9fd3c0e
+  languageName: node
+  linkType: hard
+
+"@vitejs/plugin-vue@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@vitejs/plugin-vue@npm:2.3.0"
   peerDependencies:
-    vite: ^2.5.10
-  checksum: 7cffcf10f865ba30e380a64eff5aeb69e828905833ae85a1621523d76b7de38a66549deeefecd05788919e0e31aba155d734f67fd97542a6d77046f89ae86c8c
+    vite: ^2.9.0
+    vue: ^3.2.25
+  checksum: 732ef5b08cec12303b254aa15d9f11970a5ea92bdf1314554e5241ed571df9e3b22d554fae5200ef62c88558747d1ae1f2c8814a6bc440e082facc33ab8f5e5b
   languageName: node
   linkType: hard
 
@@ -9224,13 +9410,14 @@ __metadata:
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": ^6.5.0-alpha.49
     "@storybook/test-runner": ^0.0.4
+    "@vitejs/plugin-react": ^1.3.0
     http-server: ^14.1.0
     jest: ^27.5.1
     npm-run-all: ^4.1.5
     react: ^16.4.14
     react-dom: ^16.4.14
     typescript: ^4.5.4
-    vite: 2.9.0-beta.8
+    vite: 2.9.0
     wait-on: ^6.0.1
   languageName: unknown
   linkType: soft
@@ -9245,12 +9432,13 @@ __metadata:
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": ^6.5.0-alpha.49
     "@storybook/test-runner": ^0.0.4
+    "@vitejs/plugin-react": ^1.3.0
     http-server: ^14.1.0
     jest: ^27.5.1
     npm-run-all: ^4.1.5
     react: ^16.4.14
     react-dom: ^16.4.14
-    vite: 2.9.0-beta.8
+    vite: 2.9.0
     wait-on: ^6.0.1
   languageName: unknown
   linkType: soft
@@ -9274,7 +9462,7 @@ __metadata:
     svelte: ^3.46.4
     svelte-preprocess: ^4.10.4
     typescript: ^4.5.5
-    vite: 2.9.0-beta.8
+    vite: 2.9.0
     wait-on: ^6.0.1
   languageName: unknown
   linkType: soft
@@ -9288,12 +9476,12 @@ __metadata:
     "@storybook/builder-vite": "workspace:*"
     "@storybook/test-runner": ^0.0.4
     "@storybook/vue3": ^6.5.0-alpha.49
-    "@vitejs/plugin-vue": ^1.10.2
+    "@vitejs/plugin-vue": ^2.3.0
     http-server: ^14.1.0
     jest: ^27.5.1
     npm-run-all: ^4.1.5
-    vite: 2.9.0-beta.8
-    vue: ^3.2.0
+    vite: 2.9.0
+    vue: ^3.2.25
     wait-on: ^6.0.1
   languageName: unknown
   linkType: soft
@@ -9309,7 +9497,7 @@ __metadata:
     "@storybook/react": ^6.5.0-alpha.49
     react: ^16.4.14
     react-dom: ^16.4.14
-    vite: 2.9.0-beta.7
+    vite: 2.9.0
   languageName: unknown
   linkType: soft
 
@@ -18631,9 +18819,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"vite@npm:2.9.0-beta.7":
-  version: 2.9.0-beta.7
-  resolution: "vite@npm:2.9.0-beta.7"
+"vite@npm:2.9.0":
+  version: 2.9.0
+  resolution: "vite@npm:2.9.0"
   dependencies:
     esbuild: ^0.14.27
     fsevents: ~2.3.2
@@ -18656,36 +18844,7 @@ fsevents@^1.2.7:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 9a00551f45aeacf9c78af3be2a08589a69e788698d5546a0a56c735f50830d743579ae90eb1bc04e2399d1ee3add90d224b4076a7715e8738b9ae58f03b45598
-  languageName: node
-  linkType: hard
-
-"vite@npm:2.9.0-beta.8":
-  version: 2.9.0-beta.8
-  resolution: "vite@npm:2.9.0-beta.8"
-  dependencies:
-    esbuild: ^0.14.27
-    fsevents: ~2.3.2
-    postcss: ^8.4.12
-    resolve: ^1.22.0
-    rollup: ^2.59.0
-  peerDependencies:
-    less: "*"
-    sass: "*"
-    stylus: "*"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    less:
-      optional: true
-    sass:
-      optional: true
-    stylus:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 138c5f1797509748ed2c56ecaecb6b921432aef2f3aea92c147ab29524b5ab3f677f740480034fb10e81330bb3c8b0be48f0a5f5dba2b6f0b061abe14bcb2e46
+  checksum: 2355a5a7a57a86558fb2378b493c98c97218ffdf5c7555df5531147217c8ec804d66434dfed130034c920cb0913cd5f0fa1f5d7756101601558320349c0e1cee
   languageName: node
   linkType: hard
 
@@ -18787,7 +18946,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"vue@npm:^3.2.0":
+"vue@npm:^3.2.25":
   version: 3.2.31
   resolution: "vue@npm:3.2.31"
   dependencies:


### PR DESCRIPTION
This updates the examples to the latest stable versions of vite and the vite framework plugins.

https://github.com/vitejs/vite/blob/v2.9.0/packages/vite/CHANGELOG.md

https://github.com/vitejs/vite/blob/plugin-vue@2.3.0/packages/plugin-vue/CHANGELOG.md

https://github.com/vitejs/vite/blob/plugin-react@1.3.0/packages/plugin-react/CHANGELOG.md