### PR TITLE
Add migration to readme, other updates

### DIFF
--- a/packages/builder-vite/README.md
+++ b/packages/builder-vite/README.md
@@ -1,22 +1,26 @@
 # Storybook builder for Vite
 
+Build your stories with [vite](https://vitejs.dev/) for fast startup times and near-instant HMR.
+
+## Project has been renamed
+
+This project has moved from `storybook-builder-vite` to `@storybook/builder-vite` as part of a larger effort to improve Vite support in Storybook. To automatically migrate your existing project, you can run
+
+```bash
+npx sb@next automigrate
+```
+
+To manually migrate:
+
+1. Remove `storybook-builder-vite` from your `package.json` dependencies
+2. Install `@storybook/builder-vite`
+3. Update your `core.builder` setting in `.storybook/main.js` to `@storybook/builder-vite`.
+
+### Installation
+
 Requirements:
 
 - Vite 2.5 or newer
-
-Have a look at the GitHub issues for known bugs. If you find any new bugs,
-feel free to create an issue or send a pull request!
-
-## More maintainers needed!
-
-The Vite builder cannot build itself.
-Are you willing to contribute?
-
-https://github.com/storybookjs/builder-vite/issues/11
-
-Please read the [How to contribute](/CONTRIBUTING.md) guide.
-
-### Installation
 
 ```bash
 npm install @storybook/builder-vite --save-dev
@@ -28,12 +32,20 @@ or
 yarn add --dev @storybook/builder-vite
 ```
 
+or
+
+```bash
+pnpm add --save-dev @storybook/builder-vite
+```
+
+Note: when using `pnpm`, you may need to enable [shamefully-hoist](https://pnpm.io/npmrc#shamefully-hoist), until https://github.com/storybookjs/builder-vite/issues/55 can be fixed.
+
 ### Usage
 
 In your `main.js` configuration file,
 set `core: { builder: "@storybook/builder-vite" }`.
 
-> For autoreload of stories to work, they need to have `.stories.tsx` file suffix.
+> For autoreload of react stories to work, they need to have a `.stories.tsx` or `.stories.jsx` file suffix.
 > See also [#53](https://github.com/storybookjs/builder-vite/pull/53)
 
 The builder supports both development mode in Storybook, and building a static production version.
@@ -92,29 +104,37 @@ The builder will by default enable Vite's [server.fs.strict](https://vitejs.dev/
 option, for increased security. The default project `root` is set to the parent directory of the
 storybook configuration directory. This can be overridden in viteFinal.
 
-### Getting started with React, Vite and Storybook (on a new project)
+### Getting started with Vite and Storybook (on a new project)
+
+See https://vitejs.dev/guide/#scaffolding-your-first-vite-project,
 
 ```
-npm init @vitejs/app vite-react-app --template react && cd vite-react-app
-npm install # or yarn
-npx sb@next init --builder @storybook/builder-vite && npm run storybook
+npm create vite@latest # follow the prompts
+npx sb init --builder @storybook/builder-vite && npm run storybook
 ```
 
 ## Known issues
 
-- HMR: saving a story file does not hot-module-reload. In svelte, the page is not reloaded either (https://github.com/storybookjs/builder-vite/issues/209). HMR should work when saving component files.
-- Prebundling: Vite restarts if it detects new dependencies which it did not know about and needs to pre-bundle. This breaks within storybook, with confusing error messages. If you see a message in your terminal like `[vite] new dependencies found:`, please add those dependencies to your `optimizeDeps.include` in `viteFinal`. E.g. `config.optimizeDeps.include = [...(config.optimizeDeps?.include ?? []), "storybook-dark-mode"],`.
-- MDX pages are broken when emotion 11 is installed: Adding the configuration [here](https://github.com/storybookjs/builder-vite/issues/219#issuecomment-1023666193) should fix this.
+- HMR: saving a story file does not hot-module-reload, a full reload happens instead. HMR works correctly when saving component files.
+- Prebundling: Vite restarts if it detects new dependencies which it did not know about and needs to pre-bundle. This breaks within storybook, with confusing error messages. If you see a message in your terminal like `[vite] new dependencies found:`, please add those dependencies to your `optimizeDeps.include` in `viteFinal`. E.g. `config.optimizeDeps.include = [...(config.optimizeDeps?.include ?? []), "storybook-dark-mode"],`. Vite 2.9.0 may improve this behavior.
 
 ## Contributing
 
-Contributions are welcome!
+The Vite builder cannot build itself.
+Are you willing to contribute?
+
+https://github.com/storybookjs/builder-vite/issues/11
+
+Have a look at the GitHub issues for known bugs. If you find any new bugs,
+feel free to create an issue or send a pull request!
+
+Please read the [How to contribute](/CONTRIBUTING.md) guide.
 
 ### About this codebase
 
 The code is a monorepo with the core `@storybook/builder-vite` package,
-and examples (like `packages/example-react`) to test the builder implementation with.
+and examples (like `examples/react`) to test the builder implementation.
 
-Similar to the main storybook monorepo, you need yarn , because the project is organized as yarn workspaces.
+Similar to the main storybook monorepo, you need yarn to develop this builder, because the project is organized as yarn workspaces.
 This lets you write new code in the core builder package, and instantly use them from
 the example packages.


### PR DESCRIPTION
This makes a few tweaks to our project readme:

1) Adds a `## Project has been renamed` section, with instructions how to migrate.
2) Moves the call for maintainers to the ## Contributing section, to avoid making it seem like this is a struggling project.
3) Adds pnpm installation instructions, including shameful hoisting, and moves Requirements into the installation section.
4) Updates the "for a new project" section to use `npm create vite@latest`.
5) Removes a few mentions of known issues that have been fixed. \o/