### PR TITLE
Set up addon channel before importing addons

### DIFF
--- a/packages/builder-vite/code-generator-plugin.ts
+++ b/packages/builder-vite/code-generator-plugin.ts
@@ -5,6 +5,7 @@ import { generateIframeScriptCode } from './codegen-iframe-script';
 import { generateModernIframeScriptCode } from './codegen-modern-iframe-script';
 import { generateImportFnScriptCode } from './codegen-importfn-script';
 import { generateVirtualStoryEntryCode, generatePreviewEntryCode } from './codegen-entries';
+import { generateAddonSetupCode } from './codegen-set-addon-channel';
 
 import type { Plugin } from 'vite';
 import type { ExtendedOptions } from './types';
@@ -60,6 +61,8 @@ export function codeGeneratorPlugin(options: ExtendedOptions): Plugin {
         return virtualStoriesFile;
       } else if (source === virtualPreviewFile) {
         return virtualPreviewFile;
+      } else if (source === virtualAddonSetupFile) {
+        return virtualAddonSetupFile;
       }
     },
     async load(id) {
@@ -70,6 +73,10 @@ export function codeGeneratorPlugin(options: ExtendedOptions): Plugin {
         } else {
           return generateVirtualStoryEntryCode(options);
         }
+      }
+
+      if (id === virtualAddonSetupFile) {
+        return generateAddonSetupCode();
       }
 
       if (id === virtualPreviewFile && !storyStoreV7) {

--- a/packages/builder-vite/code-generator-plugin.ts
+++ b/packages/builder-vite/code-generator-plugin.ts
@@ -9,10 +9,9 @@ import { generateVirtualStoryEntryCode, generatePreviewEntryCode } from './codeg
 import type { Plugin } from 'vite';
 import type { ExtendedOptions } from './types';
 
+import { virtualAddonSetupFile, virtualFileId, virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
+
 export function codeGeneratorPlugin(options: ExtendedOptions): Plugin {
-  const virtualFileId = '/virtual:/@storybook/builder-vite/vite-app.js';
-  const virtualStoriesFile = '/virtual:/@storybook/builder-vite/storybook-stories.js';
-  const virtualPreviewFile = '/virtual:/@storybook/builder-vite/preview-entry.js';
   const iframePath = path.resolve(__dirname, '..', 'input', 'iframe.html');
   let iframeId: string;
 
@@ -79,12 +78,9 @@ export function codeGeneratorPlugin(options: ExtendedOptions): Plugin {
 
       if (id === virtualFileId) {
         if (storyStoreV7) {
-          return generateModernIframeScriptCode(options, { storiesFilename: virtualStoriesFile });
+          return generateModernIframeScriptCode(options);
         } else {
-          return generateIframeScriptCode(options, {
-            storiesFilename: virtualStoriesFile,
-            previewFilename: virtualPreviewFile,
-          });
+          return generateIframeScriptCode(options);
         }
       }
 

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -1,5 +1,5 @@
 import { normalizePath } from 'vite';
-import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
+import { virtualPreviewFile, virtualStoriesFile, virtualAddonSetupFile } from './virtual-file-names';
 
 import type { ExtendedOptions } from './types';
 
@@ -18,6 +18,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
   /** @todo Inline variable and remove `noinspection` */
   // language=JavaScript
   const code = `
+    import '${virtualAddonSetupFile}';
     import {
       addDecorator,
       addParameters,

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -1,16 +1,9 @@
 import { normalizePath } from 'vite';
+import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
 
 import type { ExtendedOptions } from './types';
 
-interface GenerateIframeScriptCodeOptions {
-  storiesFilename: string;
-  previewFilename: string;
-}
-
-export async function generateIframeScriptCode(
-  options: ExtendedOptions,
-  { storiesFilename, previewFilename }: GenerateIframeScriptCodeOptions
-) {
+export async function generateIframeScriptCode(options: ExtendedOptions) {
   const { presets } = options;
 
   const presetEntries = await presets.apply('config', [], options);
@@ -34,9 +27,9 @@ export async function generateIframeScriptCode(
     } from '@storybook/client-api';
     import { logger } from '@storybook/client-logger';
     ${absoluteFilesToImport(configEntries, 'config')}
-    import * as preview from '${previewFilename}';
+    import * as preview from '${virtualPreviewFile}';
     // This import should occur after the config imports above
-    import { configStories } from '${storiesFilename}';
+    import { configStories } from '${virtualStoriesFile}';
 
     const configs = [${importArray('config', configEntries.length).concat('preview.default').join(',')}].filter(Boolean)
 

--- a/packages/builder-vite/codegen-modern-iframe-script.ts
+++ b/packages/builder-vite/codegen-modern-iframe-script.ts
@@ -1,16 +1,9 @@
 import { loadPreviewOrConfigFile } from '@storybook/core-common';
 import { normalizePath } from 'vite';
-
+import { virtualStoriesFile } from './virtual-file-names';
 import type { ExtendedOptions } from './types';
 
-interface GenerateModernIframeScriptCodeOptions {
-  storiesFilename: string;
-}
-
-export async function generateModernIframeScriptCode(
-  options: ExtendedOptions,
-  { storiesFilename }: GenerateModernIframeScriptCodeOptions
-) {
+export async function generateModernIframeScriptCode(options: ExtendedOptions) {
   const { presets, configDir } = options;
 
   const previewOrConfigFile = loadPreviewOrConfigFile({ configDir });
@@ -64,7 +57,7 @@ export async function generateModernIframeScriptCode(
     preview.initialize({ importFn, getProjectAnnotations });
 
     if (import.meta.hot) {
-        import.meta.hot.accept('${storiesFilename}', (newModule) => {
+        import.meta.hot.accept('${virtualStoriesFile}', (newModule) => {
 
         // importFn has changed so we need to patch the new one in
         preview.onStoriesChanged({ importFn: newModule.importFn });

--- a/packages/builder-vite/codegen-set-addon-channel.ts
+++ b/packages/builder-vite/codegen-set-addon-channel.ts
@@ -1,0 +1,19 @@
+export function generateAddonSetupCode() {
+  return `
+    import global from 'global';
+    import createPostMessageChannel from '@storybook/channel-postmessage';
+    import createWebSocketChannel from '@storybook/channel-websocket';
+    import { addons } from '@storybook/addons';
+
+    const channel = createPostMessageChannel({ page: 'preview' });
+    addons.setChannel(channel);
+    window.__STORYBOOK_ADDONS_CHANNEL__ = channel;
+
+    const { SERVER_CHANNEL_URL } = global;
+    if (SERVER_CHANNEL_URL) {
+      const serverChannel = createWebSocketChannel({ url: SERVER_CHANNEL_URL });
+      addons.setServerChannel(serverChannel);
+      window.__STORYBOOK_SERVER_CHANNEL__ = serverChannel;
+    }
+  `.trim();
+}

--- a/packages/builder-vite/input/iframe.html
+++ b/packages/builder-vite/input/iframe.html
@@ -32,6 +32,6 @@
     <div id="root"></div>
     <div id="docs-root"></div>
 
-    <script type="module" src="/virtual:/@storybook/builder-vite/vite-app.js"></script>
+    <script type="module" src="[VIRTUAL FILE ID HERE]"></script>
   </body>
 </html>

--- a/packages/builder-vite/input/iframe.html
+++ b/packages/builder-vite/input/iframe.html
@@ -31,7 +31,6 @@
     <!-- [BODY HTML SNIPPET HERE] -->
     <div id="root"></div>
     <div id="docs-root"></div>
-
-    <script type="module" src="[VIRTUAL FILE ID HERE]"></script>
+    <script type="module" src="/virtual:/@storybook/builder-vite/vite-app.js"></script>
   </body>
 </html>

--- a/packages/builder-vite/transform-iframe-html.ts
+++ b/packages/builder-vite/transform-iframe-html.ts
@@ -1,7 +1,6 @@
 import { normalizeStories } from '@storybook/core-common';
 import type { CoreConfig } from '@storybook/core-common';
 import type { ExtendedOptions } from './types';
-import { virtualFileId } from './virtual-file-names';
 
 export type PreviewHtml = string | undefined;
 
@@ -32,7 +31,6 @@ export async function transformIframeHtml(html: string, options: ExtendedOptions
     .replace(`'[FEATURES HERE]'`, JSON.stringify(features || {}))
     .replace(`'[STORIES HERE]'`, JSON.stringify(stories || {}))
     .replace(`'[SERVER_CHANNEL_URL HERE]'`, JSON.stringify(serverChannelUrl))
-    .replace('[VIRTUAL FILE ID HERE]', virtualFileId || '')
     .replace('<!-- [HEAD HTML SNIPPET HERE] -->', headHtmlSnippet || '')
     .replace('<!-- [BODY HTML SNIPPET HERE] -->', bodyHtmlSnippet || '');
 }

--- a/packages/builder-vite/transform-iframe-html.ts
+++ b/packages/builder-vite/transform-iframe-html.ts
@@ -1,6 +1,7 @@
 import { normalizeStories } from '@storybook/core-common';
 import type { CoreConfig } from '@storybook/core-common';
 import type { ExtendedOptions } from './types';
+import { virtualFileId } from './virtual-file-names';
 
 export type PreviewHtml = string | undefined;
 
@@ -31,6 +32,7 @@ export async function transformIframeHtml(html: string, options: ExtendedOptions
     .replace(`'[FEATURES HERE]'`, JSON.stringify(features || {}))
     .replace(`'[STORIES HERE]'`, JSON.stringify(stories || {}))
     .replace(`'[SERVER_CHANNEL_URL HERE]'`, JSON.stringify(serverChannelUrl))
+    .replace('[VIRTUAL FILE ID HERE]', virtualFileId || '')
     .replace('<!-- [HEAD HTML SNIPPET HERE] -->', headHtmlSnippet || '')
     .replace('<!-- [BODY HTML SNIPPET HERE] -->', bodyHtmlSnippet || '');
 }

--- a/packages/builder-vite/virtual-file-names.ts
+++ b/packages/builder-vite/virtual-file-names.ts
@@ -1,0 +1,4 @@
+export const virtualFileId = '/virtual:/@storybook/builder-vite/vite-app.js';
+export const virtualStoriesFile = '/virtual:/@storybook/builder-vite/storybook-stories.js';
+export const virtualPreviewFile = '/virtual:/@storybook/builder-vite/preview-entry.js';
+export const virtualAddonSetupFile = '/virtual:/@storybook/builder-vite/setup-addons.js';


### PR DESCRIPTION
Fixes https://github.com/storybookjs/storybook/issues/17852

This also re-organizes our virtual filenames a bit, putting them in a single file that can be imported from various spots, rather than having to pass around the strings as extra options.

To fix the issue, I pulled out the code that sets up the addon channel from the "modern" approach, and import that at the start of the non-static-store code.  It needed to be a separate file due to the way es module imports work, otherwise addon code will be imported before the channel can be created, if we tried to do it all in one file.  Bonus points for getting to share some code between the two approaches, I guess.