### PR TITLE
Add `eagerImportStories` feature for storyStoreV7

### DIFF
--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -7,6 +7,7 @@ module.exports = {
   },
   features: {
     storyStoreV7: true,
+    eagerImportStories: true,
   },
   async viteFinal(config, { configType }) {
     // customize the Vite config here

--- a/packages/builder-vite/README.md
+++ b/packages/builder-vite/README.md
@@ -42,13 +42,38 @@ Note: when using `pnpm`, you may need to enable [shamefully-hoist](https://pnpm.
 
 ### Usage
 
-In your `main.js` configuration file,
+In your `.storybook/main.js` configuration file,
 set `core: { builder: "@storybook/builder-vite" }`.
 
 > For autoreload of react stories to work, they need to have a `.stories.tsx` or `.stories.jsx` file suffix.
 > See also [#53](https://github.com/storybookjs/builder-vite/pull/53)
 
 The builder supports both development mode in Storybook, and building a static production version.
+
+It is also recommended to enable the new [on-demand story store](https://storybook.js.org/blog/storybook-on-demand-architecture/).
+
+```js
+// main.js
+
+module.exports = {
+  features: {
+    storyStoreV7: true,
+  },
+};
+```
+
+This will decrease the loading time for the first story in the browser, because each story is lazy loaded when needed. If for some reason lazy loading causes problems (e.g. due to https://github.com/vitejs/vite/issues/3924), you can disable lazy loading while still keeping the new story store with:
+
+```js
+// main.js
+
+module.exports = {
+  features: {
+    storyStoreV7: true,
+    eagerImportStories: false,
+  },
+};
+```
 
 ### Customize Vite config
 

--- a/packages/builder-vite/types/extended-options.type.ts
+++ b/packages/builder-vite/types/extended-options.type.ts
@@ -6,4 +6,8 @@ type IframeOptions = {
   title: string;
 };
 
-export type ExtendedOptions = Options & IframeOptions;
+type ViteBuilderFeatures = Options['features'] & {
+  eagerImportStories?: boolean;
+};
+
+export type ExtendedOptions = Options & IframeOptions & { features: ViteBuilderFeatures };


### PR DESCRIPTION
This feature allows the use of `storyStoreV7` without lazy loading, which can sometimes not be desired due to either bugs or the tradeoff in initial page load time vs subsequent page loads, or other reasons.  By setting the `eagerImportStores` feature flag, users will still get the improved reliability of `storyStoreV7` (which must also be enabled, this new flag has no effect without it, since the V6 store is always eager), while keeping the same story import strategy as the V6 store.

I wasn't able to find a way to actually default to `storyStoreV7` from within the builder, I think changes would be needed to core storybook itself to detect the builder and change the default.  That might not be strictly necessary right now, but we might want to consider it in the future.  I opened https://github.com/storybookjs/builder-vite/discussions/302 to ask whether anyone is using `storiesOf`, which does not work in the on-demand store. 

I did update the readme though, to draw attention to the options, and I think we should update `sb init` to set the feature if the builder is set to the vite builder.

I'm not a huge fan of adding our own special feature flag (it won't show up in intellisense, for instance), but not sure storybook core would want to add it either if it only applies to the vite builder.  I wonder if @shilman has any thoughts on a good config structure that supports builder-specific options.  Maybe we can use something like:

```js
module.exports = {
	core: {
		builder: {
			name: '@storybook/builder-vite`
			options: {
				eagerImportStories: true
			}
		}
	}
}
```

I believe that might be supported, from looking at https://github.com/storybookjs/storybook/pull/17829/files#diff-d223ae0bf47c57bb34d276bc1fdfc77cc19607c11f81133c8b0356bf0e21c80fR89.  I think I've convinced myself that's better than adding a fake feature-flag.  What do others think?