### PR TITLE
Append browserHash to absolute config imports

### DIFF
--- a/packages/builder-vite/code-generator-plugin.ts
+++ b/packages/builder-vite/code-generator-plugin.ts
@@ -15,6 +15,7 @@ import { virtualAddonSetupFile, virtualFileId, virtualPreviewFile, virtualStorie
 export function codeGeneratorPlugin(options: ExtendedOptions): Plugin {
   const iframePath = path.resolve(__dirname, '..', 'input', 'iframe.html');
   let iframeId: string;
+  let browserHash: string;
 
   // noinspection JSUnusedGlobalSymbols
   return {
@@ -87,7 +88,7 @@ export function codeGeneratorPlugin(options: ExtendedOptions): Plugin {
         if (storyStoreV7) {
           return generateModernIframeScriptCode(options);
         } else {
-          return generateIframeScriptCode(options);
+          return generateIframeScriptCode({ ...options, browserHash });
         }
       }
 
@@ -99,6 +100,9 @@ export function codeGeneratorPlugin(options: ExtendedOptions): Plugin {
       if (ctx.path !== '/iframe.html') {
         return;
       }
+      // We need the browserHash from the server so that we can append it to imports.
+      // @ts-expect-error accessing private property of server
+      browserHash = ctx.server?._optimizedDeps.metadata.browserHash ?? '';
       return transformIframeHtml(html, options);
     },
   };

--- a/packages/builder-vite/codegen-entries.ts
+++ b/packages/builder-vite/codegen-entries.ts
@@ -9,17 +9,14 @@ const absoluteFilesToImport = (files: string[], name: string) =>
   files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'/@fs/${normalizePath(el)}'`).join('\n');
 
 export async function generateVirtualStoryEntryCode(options: ExtendedOptions) {
-  const { frameworkPath, framework } = options;
   const storyEntries = await listStories(options);
   const resolveMap = storyEntries.reduce<Record<string, string>>(
     (prev, entry) => ({ ...prev, [entry]: entry.replace(slash(process.cwd()), '.') }),
     {}
   );
   const modules = storyEntries.map((entry, i) => `${JSON.stringify(entry)}: story_${i}`).join(',');
-  const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
 
   return `
-    import { configure } from '${frameworkImportPath}';
     ${absoluteFilesToImport(storyEntries, 'story')}
 
     function loadable(key) {
@@ -31,7 +28,7 @@ export async function generateVirtualStoryEntryCode(options: ExtendedOptions) {
       resolve: (key) => (${JSON.stringify(resolveMap)}[key])
     });
 
-    export function configStories() {
+    export function configStories(configure) {
       configure(loadable, { hot: import.meta.hot }, false);
     }
   `.trim();

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -4,14 +4,16 @@ import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
 import type { ExtendedOptions } from './types';
 
 export async function generateIframeScriptCode(options: ExtendedOptions) {
-  const { presets, frameworkPath, framework } = options;
+  const { presets, frameworkPath, framework, browserHash } = options;
   const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
 
   const presetEntries = await presets.apply('config', [], options);
   const configEntries = [...presetEntries].filter(Boolean);
 
   const absoluteFilesToImport = (files: string[], name: string) =>
-    files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'/@fs/${normalizePath(el)}'`).join('\n');
+    files
+      .map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'/@fs/${normalizePath(el)}?v=${browserHash}'`)
+      .join('\n');
 
   const importArray = (name: string, length: number) => new Array(length).fill(0).map((_, i) => `${name}_${i}`);
 

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -1,10 +1,11 @@
 import { normalizePath } from 'vite';
-import { virtualPreviewFile, virtualStoriesFile, virtualAddonSetupFile } from './virtual-file-names';
+import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
 
 import type { ExtendedOptions } from './types';
 
 export async function generateIframeScriptCode(options: ExtendedOptions) {
-  const { presets } = options;
+  const { presets, frameworkPath, framework } = options;
+  const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
 
   const presetEntries = await presets.apply('config', [], options);
   const configEntries = [...presetEntries].filter(Boolean);
@@ -18,7 +19,10 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
   /** @todo Inline variable and remove `noinspection` */
   // language=JavaScript
   const code = `
-    import '${virtualAddonSetupFile}';
+    // Ensure that the client API is initialized by the framework before any other iframe code
+    // is loaded. That way our client-apis can assume the existence of the API+store
+    import { configure } from '${frameworkImportPath}';
+
     import {
       addDecorator,
       addParameters,
@@ -29,7 +33,6 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
     import { logger } from '@storybook/client-logger';
     ${absoluteFilesToImport(configEntries, 'config')}
     import * as preview from '${virtualPreviewFile}';
-    // This import should occur after the config imports above
     import { configStories } from '${virtualStoriesFile}';
 
     const configs = [${importArray('config', configEntries.length).concat('preview.default').join(',')}].filter(Boolean)
@@ -81,7 +84,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
     }
     */
 
-    configStories();
+    configStories(configure);
     `.trim();
   return code;
 }

--- a/packages/builder-vite/optimizeDeps.ts
+++ b/packages/builder-vite/optimizeDeps.ts
@@ -10,20 +10,7 @@ const INCLUDE_CANDIDATES = [
   '@emotion/is-prop-valid',
   '@emotion/styled',
   '@mdx-js/react',
-  '@storybook/addon-docs > acorn-jsx',
-  '@storybook/addon-docs',
-  '@storybook/addons',
-  '@storybook/channel-postmessage',
-  '@storybook/channel-websocket',
-  '@storybook/client-api',
-  '@storybook/client-logger',
-  '@storybook/core/client',
   '@storybook/csf',
-  '@storybook/preview-web',
-  '@storybook/react > acorn-jsx',
-  '@storybook/react',
-  '@storybook/svelte',
-  '@storybook/vue3',
   'acorn-jsx',
   'acorn-walk',
   'acorn',
@@ -119,5 +106,14 @@ export async function getOptimizeDeps(
     // We need Vite to precompile these dependencies, because they contain non-ESM code that would break
     // if we served it directly to the browser.
     include,
+    // TODO: It's unclear why these are attempted to be optimized, when they don't need it.
+    exclude: [
+      '@storybook/addon-docs',
+      '@storybook/client-api',
+      '@storybook/client-logger',
+      '@storybook/react',
+      '@storybook/svelte',
+      '@storybook/vue3',
+    ],
   };
 }

--- a/packages/builder-vite/types/extended-options.type.ts
+++ b/packages/builder-vite/types/extended-options.type.ts
@@ -4,6 +4,7 @@ import type { Options } from '@storybook/core-common';
 type IframeOptions = {
   frameworkPath: string;
   title: string;
+  browserHash: string;
 };
 
 export type ExtendedOptions = Options & IframeOptions;


### PR DESCRIPTION
This reverts commit https://github.com/storybookjs/builder-vite/pull/289, and fixes https://github.com/storybookjs/storybook/issues/17773 a different way.

@tmeasday and I determined that the `start()` function in [app/vue3/src/client/preview/index.ts](https://github.com/storybookjs/storybook/blob/534e61855717fea1ff7ce554523a4d59ff453553/app/vue3/src/client/preview/index.ts#L25) was being called twice, once with all the parameters, and once with just the framework renderer.  Eventually I realized that one of the urls calling start was something like `http://localhost:6006/node_modules/@storybook/vue3/dist/esm/client/preview/index.js?v=afbc4050` and the other was `http://localhost:6006/node_modules/@storybook/vue3/dist/esm/client/preview/index.js` (notice no `v=browserHash` at the end).  It seems this is due to several things:

- Using the `/@fs/` syntax to point to a file on the filesystem, rather than a node_module (maybe vite doesn't automatically append the browser hash in this case?  Maybe @patak-dev can confirm.)
- Pre-bundling several `@storybook` packages, even though there were esm exports available to import.  I'm not sure why these are being pre-bundled, but excluding them was necessary to avoid the double-start.

The "fix" here is a bit of a hack, and I'd like to find a better way.  I'm grabbing the `browserHash` from a private property of the server (not sure what versions of vite this even works with), and manually appending it to the filenames that we're generating.  That alone wasn't enough to fix the problem, though, as I also needed to prevent the `@storybook` packages from being optimized.  

Lastly, this only works if one more change is made to storybook frameworks, to change [this line](https://github.com/storybookjs/storybook/blob/534e61855717fea1ff7ce554523a4d59ff453553/app/vue3/src/client/preview/index.ts#L2) (and it's equivalent in each framework) from 

```js
import { start } from '@storybook/core/client';
```

to 

```js
import { start } from '@storybook/core-client';
```

Because `@storybook/core/client.js` is a cjs file.

I hope that maybe some of the vite folks can help suggest a better way than manually appending a browserHash.  I may need to put together a simpler reproduction of the issue that better demonstrates what's going on, but I'm not convinced I'll be able to.

Or, maybe we can change / resolve the absolute paths into normal bare imports and allow the typical import resolution to occur?  I.e. change from:

```js
import * as config_1 from '/@fs//Users/ianvs/code/experiments/sb-builder-vite-no-container/node_modules/@storybook/vue3/dist/esm/client/preview/config'
```

to something like:

```js
import * as config_1 from '@storybook/vue3/client/preview/config'
```

But I think that would require a change to core storybook, and might break the webpack builders.