### PR TITLE
Check for explicit typescript dep

### DIFF
--- a/examples/react/.storybook/main.js
+++ b/examples/react/.storybook/main.js
@@ -12,9 +12,4 @@ module.exports = {
     // customize the Vite config here
     return config;
   },
-  // Normally this wouldn't be necessary, but `react-docgen-typescript` is the default,
-  // and since typescript is installed in the monorepo, we can't rely on that check.
-  typescript: {
-    reactDocgen: 'react-docgen',
-  },
 };

--- a/packages/builder-vite/vite-config.ts
+++ b/packages/builder-vite/vite-config.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import fs from 'fs';
 import { Plugin } from 'vite';
 import { allowedEnvPrefix as envPrefix } from './envs';
 import { TypescriptConfig } from '@storybook/core-common';
@@ -12,6 +13,16 @@ import type { UserConfig } from 'vite';
 import type { ExtendedOptions } from './types';
 
 export type PluginConfigType = 'build' | 'development';
+
+export function readPackageJson(): Record<string, any> | false {
+  const packageJsonPath = path.resolve('package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    return false;
+  }
+
+  const jsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+  return JSON.parse(jsonContent);
+}
 
 // Vite config that is common to development and production mode
 export async function commonConfig(
@@ -108,8 +119,8 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
     let typescriptPresent;
 
     try {
-      require.resolve('typescript');
-      typescriptPresent = true;
+      const pkgJson = readPackageJson();
+      typescriptPresent = pkgJson && (pkgJson?.devDependencies?.typescript || pkgJson?.dependencies?.typescript);
     } catch (e) {
       typescriptPresent = false;
     }


### PR DESCRIPTION
Fixes #312.

Previously, we'd just look to see if typescript was in the project at all, but turns out that it can be included as a peer dependency of some storybook dependencies.

So, this tightens the check a bit, to search the `package.json` for `typescript` in either `devDependencies` or `dependencies` (in case someone forgot to use `--save-dev` I guess).  

To verify, I removed the `typescript` config from our react example (that should have been a clue to me this was broken, I assumed it was due to our monorepo), and I also checked that `vite:react-docgen-typescript` is still being used in our react-ts example.