### PR TITLE
chore(docs): update readme to use mergeConfig vite helper function

### DIFF
--- a/packages/builder-vite/README.md
+++ b/packages/builder-vite/README.md
@@ -67,8 +67,8 @@ module.exports = {
     return mergeConfig(config, {
       // customize the Vite config here
       resolve: {
-        alias: { foo: 'bar' }
-      }
+        alias: { foo: 'bar' },
+      },
     });
   },
   // ... other options here

--- a/packages/builder-vite/README.md
+++ b/packages/builder-vite/README.md
@@ -58,7 +58,7 @@ In `.storybook/main.js` (or whatever your Storybook config file is named)
 you can override the Vite config:
 
 ```javascript
-// use `mergeConfig` to recursively merge vite options
+// use `mergeConfig` to recursively merge Vite options
 const { mergeConfig } = require('vite');
 
 module.exports = {

--- a/packages/builder-vite/README.md
+++ b/packages/builder-vite/README.md
@@ -58,13 +58,18 @@ In `.storybook/main.js` (or whatever your Storybook config file is named)
 you can override the Vite config:
 
 ```javascript
+// use `mergeConfig` to recursively merge vite options
+const { mergeConfig } = require('vite');
+
 module.exports = {
   async viteFinal(config, { configType }) {
-    // customize the Vite config here
-    config.resolve.alias.foo = 'bar';
-
     // return the customized config
-    return config;
+    return mergeConfig(config, {
+      // customize the Vite config here
+      resolve: {
+        alias: { foo: 'bar' }
+      }
+    });
   },
   // ... other options here
 };


### PR DESCRIPTION
## Summary
Recommend users to use the [`mergeConfig` vite helper function](https://github.com/vitejs/vite/blob/77dc1a19b4f6f079a3861773b63e36177f32504d/packages/vite/src/node/config.ts#L768-L774) to easily recursively merge config options without troublesome nesting and object spreading shallow copy pitfalls.