### PR TITLE
Do not optimize storybook packages, if possible

### DIFF
--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -24,12 +24,14 @@
     "glob-promise": "^4.2.0",
     "magic-string": "^0.26.1",
     "react-docgen": "^6.0.0-alpha.0",
+    "semver": "^7.3.5",
     "slash": "^3.0.0",
     "vite-plugin-mdx": "^3.5.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/node": "^17.0.23",
+    "@types/semver": "^7.3.9",
     "vue-docgen-api": "^4.40.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3502,6 +3502,7 @@ __metadata:
     "@storybook/source-loader": ^6.3.12
     "@types/express": ^4.17.13
     "@types/node": ^17.0.23
+    "@types/semver": ^7.3.9
     "@vitejs/plugin-react": ^1.0.8
     ast-types: ^0.14.2
     es-module-lexer: ^0.9.3
@@ -3509,6 +3510,7 @@ __metadata:
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
     react-docgen: ^6.0.0-alpha.0
+    semver: ^7.3.5
     slash: ^3.0.0
     vite-plugin-mdx: ^3.5.6
     vue-docgen-api: ^4.40.0
@@ -4884,6 +4886,13 @@ __metadata:
   version: 0.16.1
   resolution: "@types/scheduler@npm:0.16.1"
   checksum: 2ff8034df029a6cbb3623b05fa895cac4fc504806a8e948ebe29675a1edfa5ac04faac7611016076b3ffefc2037bbe344ad1978304059b2d4c78e513ec43c7bf
+  languageName: node
+  linkType: hard
+
+"@types/semver@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@types/semver@npm:7.3.9"
+  checksum: 60bfcfdfa7f937be2c6f4b37ddb6714fb0f27b05fe4cbdfdd596a97d35ed95d13ee410efdd88e72a66449d0384220bf20055ab7d6b5df10de4990fbd20e5cbe0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR removes many of the storybook packages from pre-bundling, which should save a little bit of time in startup, and will 🤞 work a little better in pnpm (see https://github.com/storybookjs/builder-vite/issues/55, although this probably doesn't fix it yet).  

Furthermore, after storybook 6.5.0-alpha.58, we can exclude the framework packages from pre-bundling also, but in versions earlier than that, we do need to pre-bundle.  So I added a dependency on `semver`, to compare the storybook framework's version from package.json and determine whether to pre-bundle it or not.  I tested back to 6.4.0, and it worked fine as long as I added titles to stories (autotitle wasn't working that far back).  

Here's the difference it makes in the pre-bundled files:

Before:
<img width="343" alt="Pasted_Image_4_7_22__11_31_PM" src="https://user-images.githubusercontent.com/4616705/162357449-de936070-b450-4873-bb0a-ffb29a9f1645.png">


After:
<img width="346" alt="Pasted_Image_4_7_22__11_31_PM" src="https://user-images.githubusercontent.com/4616705/162357382-65933d1d-bf00-422a-b95a-3eb5ecf62c2e.png">

