### PR TITLE
Correctly import/prebundle V6 store configs

### DIFF
--- a/packages/builder-vite/codegen-entries.ts
+++ b/packages/builder-vite/codegen-entries.ts
@@ -9,17 +9,14 @@ const absoluteFilesToImport = (files: string[], name: string) =>
   files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'/@fs/${normalizePath(el)}'`).join('\n');
 
 export async function generateVirtualStoryEntryCode(options: ExtendedOptions) {
-  const { frameworkPath, framework } = options;
   const storyEntries = await listStories(options);
   const resolveMap = storyEntries.reduce<Record<string, string>>(
     (prev, entry) => ({ ...prev, [entry]: entry.replace(slash(process.cwd()), '.') }),
     {}
   );
   const modules = storyEntries.map((entry, i) => `${JSON.stringify(entry)}: story_${i}`).join(',');
-  const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
 
   return `
-    import { configure } from '${frameworkImportPath}';
     ${absoluteFilesToImport(storyEntries, 'story')}
 
     function loadable(key) {
@@ -31,7 +28,7 @@ export async function generateVirtualStoryEntryCode(options: ExtendedOptions) {
       resolve: (key) => (${JSON.stringify(resolveMap)}[key])
     });
 
-    export function configStories() {
+    export function configStories(configure) {
       configure(loadable, { hot: import.meta.hot }, false);
     }
   `.trim();

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -1,7 +1,14 @@
-import { normalizePath } from 'vite';
 import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
 
 import type { ExtendedOptions } from './types';
+
+// We need to convert from an absolute path, to a traditional node module import path,
+// so that vite can correctly pre-bundle/optimize
+function transformPath(absPath: string) {
+  const splits = absPath.split('node_modules/');
+  // Return everything after the final "node_modules/"
+  return splits[splits.length - 1];
+}
 
 export async function generateIframeScriptCode(options: ExtendedOptions) {
   const { presets, frameworkPath, framework } = options;
@@ -11,7 +18,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
   const configEntries = [...presetEntries].filter(Boolean);
 
   const absoluteFilesToImport = (files: string[], name: string) =>
-    files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'/@fs/${normalizePath(el)}'`).join('\n');
+    files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'${transformPath(el)}'`).join('\n');
 
   const importArray = (name: string, length: number) => new Array(length).fill(0).map((_, i) => `${name}_${i}`);
 

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -1,10 +1,11 @@
 import { normalizePath } from 'vite';
-import { virtualPreviewFile, virtualStoriesFile, virtualAddonSetupFile } from './virtual-file-names';
+import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
 
 import type { ExtendedOptions } from './types';
 
 export async function generateIframeScriptCode(options: ExtendedOptions) {
-  const { presets } = options;
+  const { presets, frameworkPath, framework } = options;
+  const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
 
   const presetEntries = await presets.apply('config', [], options);
   const configEntries = [...presetEntries].filter(Boolean);
@@ -18,7 +19,10 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
   /** @todo Inline variable and remove `noinspection` */
   // language=JavaScript
   const code = `
-    import '${virtualAddonSetupFile}';
+    // Ensure that the client API is initialized by the framework before any other iframe code
+    // is loaded. That way our client-apis can assume the existence of the API+store
+    import { configure } from '${frameworkImportPath}';
+
     import {
       addDecorator,
       addParameters,
@@ -29,7 +33,6 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
     import { logger } from '@storybook/client-logger';
     ${absoluteFilesToImport(configEntries, 'config')}
     import * as preview from '${virtualPreviewFile}';
-    // This import should occur after the config imports above
     import { configStories } from '${virtualStoriesFile}';
 
     const configs = [${importArray('config', configEntries.length).concat('preview.default').join(',')}].filter(Boolean)
@@ -81,7 +84,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
     }
     */
 
-    configStories();
+    configStories(configure);
     `.trim();
   return code;
 }

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+import { normalizePath } from 'vite';
 import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
 
 import type { ExtendedOptions } from './types';
@@ -5,9 +7,10 @@ import type { ExtendedOptions } from './types';
 // We need to convert from an absolute path, to a traditional node module import path,
 // so that vite can correctly pre-bundle/optimize
 function transformPath(absPath: string) {
-  const splits = absPath.split('node_modules/');
+  const splits = absPath.split(`node_modules${path.sep}`);
   // Return everything after the final "node_modules/"
-  return splits[splits.length - 1];
+  const module = normalizePath(splits[splits.length - 1]);
+  return module;
 }
 
 export async function generateIframeScriptCode(options: ExtendedOptions) {


### PR DESCRIPTION
Closes https://github.com/storybookjs/builder-vite/pull/305

This reverts https://github.com/storybookjs/builder-vite/pull/289, and fixes it a better way, by replacing filesystem imports (`/@fs/` style absolute path imports) with normal node_modules style imports.  So, instead of:

```
/@fs/Users/ianvs/code/experiments/sb-builder-vite-no-container/node_modules/@storybook/vue3/dist/esm/client/preview/config
```

We'll import from 

```
@storybook/vue3/dist/esm/client/preview/config
```

Which vite can correctly pre-bundle and add a browserHash to.

To test this, run the vue example in this repo.  You should see some messages about new dependencies being optimized in the terminal, and the storybook should load up just fine with no errors about `No docs.container set`.

I tested this out back to our minimum supported versions of vite (2.5.2) and storybook (6.4.0).  It worked fine, although at that old version, one page refresh was required on the very first startup (due to changes in pre-bundled deps).  This doesn't happen in vite 2.9.0, which has better support for finding new deps.