### PR TITLE
Revert "Do not optimize storybook packages (#323)"

### DIFF
--- a/packages/builder-vite/optimizeDeps.ts
+++ b/packages/builder-vite/optimizeDeps.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import { normalizePath, resolveConfig, UserConfig } from 'vite';
 import { listStories } from './list-stories';
-import semver from 'semver';
 
 import type { ExtendedOptions } from './types';
 
@@ -11,7 +10,20 @@ const INCLUDE_CANDIDATES = [
   '@emotion/is-prop-valid',
   '@emotion/styled',
   '@mdx-js/react',
+  '@storybook/addon-docs > acorn-jsx',
+  '@storybook/addon-docs',
+  '@storybook/addons',
+  '@storybook/channel-postmessage',
+  '@storybook/channel-websocket',
+  '@storybook/client-api',
+  '@storybook/client-logger',
+  '@storybook/core/client',
   '@storybook/csf',
+  '@storybook/preview-web',
+  '@storybook/react > acorn-jsx',
+  '@storybook/react',
+  '@storybook/svelte',
+  '@storybook/vue3',
   'acorn-jsx',
   'acorn-walk',
   'acorn',
@@ -97,21 +109,7 @@ export async function getOptimizeDeps(
   const stories = absoluteStories.map((storyPath) => normalizePath(path.relative(root, storyPath)));
   const resolvedConfig = await resolveConfig(config, 'serve', 'development');
 
-  // This function converts ids which might include ` > ` to a real path, if it exists on disk.
-  // See https://github.com/vitejs/vite/blob/67d164392e8e9081dc3f0338c4b4b8eea6c5f7da/packages/vite/src/node/optimizer/index.ts#L182-L199
-  const resolve = resolvedConfig.createResolver({ asSrc: false });
-  const include = await asyncFilter(INCLUDE_CANDIDATES, async (id) => Boolean(await resolve(id)));
-
-  // We can exclude some packages which otherwise are optimized
-  const exclude = [
-    '@storybook/addon-docs',
-    '@storybook/client-api',
-    '@storybook/client-logger',
-    '@storybook/preview-web',
-    '@storybook/channel-postmessage',
-    '@storybook/channel-websocket',
-    '@storybook/addons',
-  ];
+  const exclude = [];
   // This is necessary to support react < 18 with new versions of @storybook/react that support react 18.
   // TODO: narrow this down to just framework === 'react'.  But causes a vue dev start problem in this monorepo.
   try {
@@ -121,16 +119,11 @@ export async function getOptimizeDeps(
       exclude.push('react-dom/client');
     }
   }
-  // Depending on the user's storybook version, we can also exclude the framework from prebundling
-  // See https://github.com/storybookjs/storybook/pull/17875
-  const { frameworkPath, framework } = options;
-  const frameworkPackageName = frameworkPath || `@storybook/${framework}`;
-  const sbVersion: string | undefined = (await import(`${frameworkPackageName}/package.json`))?.version;
-  if (sbVersion && semver.gte(sbVersion, '6.5.0-alpha.58', { includePrerelease: true })) {
-    exclude.push(frameworkPackageName);
-  } else {
-    include.push(frameworkPackageName);
-  }
+
+  // This function converts ids which might include ` > ` to a real path, if it exists on disk.
+  // See https://github.com/vitejs/vite/blob/67d164392e8e9081dc3f0338c4b4b8eea6c5f7da/packages/vite/src/node/optimizer/index.ts#L182-L199
+  const resolve = resolvedConfig.createResolver({ asSrc: false });
+  const include = await asyncFilter(INCLUDE_CANDIDATES, async (id) => Boolean(await resolve(id)));
 
   return {
     // We don't need to resolve the glob since vite supports globs for entries.

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -24,14 +24,12 @@
     "glob-promise": "^4.2.0",
     "magic-string": "^0.26.1",
     "react-docgen": "^6.0.0-alpha.0",
-    "semver": "^7.3.5",
     "slash": "^3.0.0",
     "vite-plugin-mdx": "^3.5.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/node": "^17.0.23",
-    "@types/semver": "^7.3.9",
     "vue-docgen-api": "^4.40.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,7 +3385,6 @@ __metadata:
     "@storybook/source-loader": ^6.4.3
     "@types/express": ^4.17.13
     "@types/node": ^17.0.23
-    "@types/semver": ^7.3.9
     "@vitejs/plugin-react": ^1.0.8
     ast-types: ^0.14.2
     es-module-lexer: ^0.9.3
@@ -3393,7 +3392,6 @@ __metadata:
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
     react-docgen: ^6.0.0-alpha.0
-    semver: ^7.3.5
     slash: ^3.0.0
     vite-plugin-mdx: ^3.5.6
     vue-docgen-api: ^4.40.0
@@ -4746,13 +4744,6 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: 19eb71acc4b0d7db2170732a51ad18a34007021f42069652a5be8a3e3a448a470d2f970b9e85f734d1896bf3a25e48fb5132b4a989c101eb5df21cc171d426c5
-  languageName: node
-  linkType: hard
-
-"@types/semver@npm:^7.3.9":
-  version: 7.3.9
-  resolution: "@types/semver@npm:7.3.9"
-  checksum: 60bfcfdfa7f937be2c6f4b37ddb6714fb0f27b05fe4cbdfdd596a97d35ed95d13ee410efdd88e72a66449d0384220bf20055ab7d6b5df10de4990fbd20e5cbe0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/storybookjs/builder-vite/issues/327

This reverts https://github.com/storybookjs/builder-vite/pull/323.

While I still think it would be great to avoid including deps in our `optimizeDeps.include` as much as we can, it turns out that it's still necessary for a few reasons.  

1) If an addon (like `storybook-dark-mode`) publishes a cjs package that `require()`s from a storybook package that has been excluded from optimization, then esbuild seems to not replace that require at build time as it normally would. 

>Some background: esbuild's bundler emulates a CommonJS environment. The bundling process replaces the literal syntax require(<string>) with the referenced module at compile-time. 

(https://github.com/evanw/esbuild/blob/master/CHANGELOG.md#01229)

This results in the situation outlined in #327.

2) Even after I removed all the packages from `exclude`, if I didn't add them back to the `include` list, there were multiple page refreshes while the app booted the first time, while vite found new deps and reloaded the page.  That would only happen once until the cache was populated, which isn't horrible, but it's not a great experience either.

3) Lastly, if I tried to keep the logic which prevented optimizing the storybook framework package, I ended up with react hook warnings, which usually means that multiple versions of react are loaded in the page.  That was the final straw which made me decide to completely revert the PR and go back to what we had before.  When I did that, my storybook worked just fine.

I think we can take another stab at avoiding optimization another time, but we've already made a lot of changes to this package lately and it doesn't seem to be causing problems like I initially suspected in https://github.com/storybookjs/builder-vite/pull/305.