### PR TITLE
Avoid @fs imports for storyStoreV7

### DIFF
--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -1,17 +1,6 @@
-import path from 'path';
-import { normalizePath } from 'vite';
 import { virtualPreviewFile, virtualStoriesFile } from './virtual-file-names';
-
+import { transformAbsPath } from './utils/transform-abs-path';
 import type { ExtendedOptions } from './types';
-
-// We need to convert from an absolute path, to a traditional node module import path,
-// so that vite can correctly pre-bundle/optimize
-function transformPath(absPath: string) {
-  const splits = absPath.split(`node_modules${path.sep}`);
-  // Return everything after the final "node_modules/"
-  const module = normalizePath(splits[splits.length - 1]);
-  return module;
-}
 
 export async function generateIframeScriptCode(options: ExtendedOptions) {
   const { presets, frameworkPath, framework } = options;
@@ -21,7 +10,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
   const configEntries = [...presetEntries].filter(Boolean);
 
   const absoluteFilesToImport = (files: string[], name: string) =>
-    files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'${transformPath(el)}'`).join('\n');
+    files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'${transformAbsPath(el)}'`).join('\n');
 
   const importArray = (name: string, length: number) => new Array(length).fill(0).map((_, i) => `${name}_${i}`);
 

--- a/packages/builder-vite/codegen-modern-iframe-script.ts
+++ b/packages/builder-vite/codegen-modern-iframe-script.ts
@@ -1,6 +1,6 @@
 import { loadPreviewOrConfigFile } from '@storybook/core-common';
-import { normalizePath } from 'vite';
 import { virtualStoriesFile, virtualAddonSetupFile } from './virtual-file-names';
+import { transformAbsPath } from './utils/transform-abs-path';
 import type { ExtendedOptions } from './types';
 
 export async function generateModernIframeScriptCode(options: ExtendedOptions) {
@@ -10,7 +10,7 @@ export async function generateModernIframeScriptCode(options: ExtendedOptions) {
   const presetEntries = await presets.apply('config', [], options);
   const configEntries = [...presetEntries, previewOrConfigFile]
     .filter(Boolean)
-    .map((configEntry) => `/@fs/${normalizePath(configEntry)}`);
+    .map((configEntry) => transformAbsPath(configEntry));
 
   // noinspection UnnecessaryLocalVariableJS
   /**

--- a/packages/builder-vite/utils/transform-abs-path.ts
+++ b/packages/builder-vite/utils/transform-abs-path.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+import { normalizePath } from 'vite';
+
+// We need to convert from an absolute path, to a traditional node module import path,
+// so that vite can correctly pre-bundle/optimize
+export function transformAbsPath(absPath: string) {
+  const splits = absPath.split(`node_modules${path.sep}`);
+  // Return everything after the final "node_modules/"
+  const module = normalizePath(splits[splits.length - 1]);
+  return module;
+}


### PR DESCRIPTION
Similar to https://github.com/storybookjs/builder-vite/pull/324, this avoids the use of `/@fs/` imports in the modern loader, with `storyStoreV7` enabled.

To test, use the react-ts example, install `@storybook/addon-bench`, add it to the `addons` list in `main.js`, and try starting storybook.  It will fail in main, but pass in this branch.