### PR TITLE
react-docgen: exclude node_modules, make configurable

### DIFF
--- a/packages/builder-vite/plugins/react-docgen.ts
+++ b/packages/builder-vite/plugins/react-docgen.ts
@@ -24,9 +24,9 @@ type Options = {
   exclude?: string | RegExp | (string | RegExp)[];
 };
 
-// pattern /^..\// prevents files that are outside of the project root (process.cwd());
-const DEFAULT_EXCLUDE = [/node_modules\/.*/, /^..\//];
-export function reactDocgen(options: Options = { include: /\.(mjs|tsx?|jsx?)$/, exclude: DEFAULT_EXCLUDE }): Plugin {
+export function reactDocgen(
+  options: Options = { include: /\.(mjs|tsx?|jsx?)$/, exclude: [/node_modules\/.*/] }
+): Plugin {
   const cwd = process.cwd();
   const filter = createFilter(options.include, options.exclude);
 

--- a/packages/builder-vite/plugins/react-docgen.ts
+++ b/packages/builder-vite/plugins/react-docgen.ts
@@ -24,11 +24,9 @@ type Options = {
   exclude?: string | RegExp | (string | RegExp)[];
 };
 
-export function reactDocgen(
-  options: Options = { include: /\.(mjs|tsx?|jsx?)$/, exclude: [/node_modules\/.*/] }
-): Plugin {
+export function reactDocgen({ include = /\.(mjs|tsx?|jsx?)$/, exclude = [/node_modules\/.*/] }: Options = {}): Plugin {
   const cwd = process.cwd();
-  const filter = createFilter(options.include, options.exclude);
+  const filter = createFilter(include, exclude);
 
   return {
     name: 'react-docgen',

--- a/packages/builder-vite/plugins/react-docgen.ts
+++ b/packages/builder-vite/plugins/react-docgen.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+import { createFilter } from '@rollup/pluginutils';
 import {
   parse,
   handlers as docgenHandlers,
@@ -17,36 +19,46 @@ const defaultResolver = docgenResolver.findAllExportedComponentDefinitions;
 const defaultImporter = docgenImporters.makeFsImporter();
 const handlers = [...defaultHandlers, actualNameHandler];
 
-export function reactDocgen(): Plugin {
+type Options = {
+  include?: string | RegExp | (string | RegExp)[];
+  exclude?: string | RegExp | (string | RegExp)[];
+};
+
+// pattern /^..\// prevents files that are outside of the project root (process.cwd());
+const DEFAULT_EXCLUDE = [/node_modules\/.*/, /^..\//];
+export function reactDocgen(options: Options = { include: /\.(mjs|tsx?|jsx?)$/, exclude: DEFAULT_EXCLUDE }): Plugin {
+  const cwd = process.cwd();
+  const filter = createFilter(options.include, options.exclude);
+
   return {
     name: 'react-docgen',
     enforce: 'pre',
     async transform(src: string, id: string) {
-      // JSX syntax is only allowed in .tsx and .jsx, but components can technically be created without JSX
-      if (/\.(mjs|tsx?|jsx?)$/.test(id)) {
-        try {
-          // Since we're using `findAllExportedComponentDefinitions`, this will always be an array.
-          const docgenResults = parse(src, defaultResolver, handlers, { importer: defaultImporter, filename: id }) as
-            | DocObj[];
-          const s = new MagicString(src);
+      const relPath = path.relative(cwd, id);
+      if (!filter(relPath)) return;
 
-          docgenResults.forEach((info) => {
-            const { actualName, ...docgenInfo } = info;
-            if (actualName) {
-              const docNode = JSON.stringify(docgenInfo);
-              s.append(`;${actualName}.__docgenInfo=${docNode}`);
-            }
-          });
+      try {
+        // Since we're using `findAllExportedComponentDefinitions`, this will always be an array.
+        const docgenResults = parse(src, defaultResolver, handlers, { importer: defaultImporter, filename: id }) as
+          | DocObj[];
+        const s = new MagicString(src);
 
-          return {
-            code: s.toString(),
-            map: s.generateMap(),
-          };
-        } catch (e) {
-          // Usually this is just an error from react-docgen that it couldn't find a component
-          // Only uncomment for troubleshooting
-          // console.error(e);
-        }
+        docgenResults.forEach((info) => {
+          const { actualName, ...docgenInfo } = info;
+          if (actualName) {
+            const docNode = JSON.stringify(docgenInfo);
+            s.append(`;${actualName}.__docgenInfo=${docNode}`);
+          }
+        });
+
+        return {
+          code: s.toString(),
+          map: s.generateMap(),
+        };
+      } catch (e) {
+        // Usually this is just an error from react-docgen that it couldn't find a component
+        // Only uncomment for troubleshooting
+        // console.error(e);
       }
     },
   };


### PR DESCRIPTION
This updates the internal react-docgen plugin to prevent running against files that are in node_modules ~or outside of the project root~.

I realized we should do this when working on converting a large project over to use the vite builder as an experiment, and found that it took ~20 minutes to load the first storybook page after the browser opened.  After digging, I found that most of this time was spent processing files that were in other parts of the monorepo, like icons, which did not need docgen info.  After making the changes in this PR, the time was reduced to less than 2 minutes on a cold start.  The number of processed files dropped from 1668 to 958.  And the time drops to 20 seconds for a cold boot with storyStoreV7 (processes 39 files).

I'm making a few assumptions here:

1) Components in node_modules should not get docgen information.  I think this is reasonable, since it's unlikely you need to document imported components, they should be documented elsewhere.

~2) Components outside of your project root (technically, I'm using `process.cwd()` here)  should likewise not get docgen.  This may not always be a good assumption to make, and by supplying this exclude pattern as a default parameter, I'm thinking we could easily pull this plugin into a separate package and allow users to customize it.  But, more often than not, I think this is the right decision to exclude them.  Curious to hear other's thoughts though.~

This is configurable, although it's not super-straightforward.  For example:

```js
async viteFinal(config) {
    config.plugins = [
      require('@storybook/builder-vite/dist/plugins/react-docgen').reactDocgen({
        exclude: [/^\.\.\//, /node_modules/],
        include: /\.(jsx?)$/,
      }),
      ...config.plugins.filter((plugin) => plugin?.name !== 'react-docgen'),
    ];
    return config;
}
```

Note that `react-docgen` needs to happen before the `@vitejs/plugin-react` plugins, which is why it's above the spread of the rest of the plugins in this example. 