### PR TITLE
Add custom issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,40 @@
+name: "\U0001F41B Bug Report"
+description: Report an issue or possible bug
+title: "[Bug] "
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to file a bug report! Please fill out this form as completely as possible, it will help us address your problem more quickly.
+  - type: input
+    attributes:
+      label: What version of `vite` are you using?
+      placeholder: 0.0.0
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: System info and storybook versions
+      placeholder: Please paste the results of `npx sb@next info`` here
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.  What do you expect, vs what is happening?  Screenshots and logs are helpful as well.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Link to Minimal Reproducible Example
+      description: 'Use `npm create vite@latest` and then `npx sb@next init` to create a minimal reproduction of the problem, document any additional steps in README.md, and push up the repo to github.  We prioritize issues with reproductions over those without.'
+      placeholder: 'https://github.com/ianvs/storybook-vite-issue-repro'
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Participation
+      options:
+        - label:  I am willing to submit a pull request for this issue.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 👾 Chat
+    url: https://discord.gg/uST2e5y4XA
+    about: Come join the \#vite channel in the storybook discord.
+  - name: 💬 Discussion & Support
+    url: https://github.com/storybookjs/builder-vite/discussions
+    about: Ask a question, or share an idea.


### PR DESCRIPTION
This issue template is a combination of ideas from astro, vite, and storybook.  I think it might help us get more helpful information right off the bat, without having to ask for more details and reproductions.

I also added links to the discord and GitHub discussions.