### PR TITLE
Warn in console when storyStoreV7 used with .svelte files

### DIFF
--- a/examples/svelte/.storybook/main.js
+++ b/examples/svelte/.storybook/main.js
@@ -7,6 +7,10 @@ module.exports = {
   core: {
     builder: '@storybook/builder-vite',
   },
+  features: {
+    // On-demand store does not work for .svelte stories, only CSF.
+    storyStoreV7: false,
+  },
   async viteFinal(config, { configType }) {
     // customize the Vite config here
     return config;

--- a/packages/builder-vite/codegen-importfn-script.ts
+++ b/packages/builder-vite/codegen-importfn-script.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { normalizePath } from 'vite';
 import type { Options } from '@storybook/core-common';
+import { logger } from '@storybook/node-logger';
 
 import { listStories } from './list-stories';
 
@@ -26,7 +27,13 @@ function toImportPath(relativePath: string) {
  */
 async function toImportFn(stories: string[]) {
   const objectEntries = stories.map((file) => {
-    return `  '${toImportPath(normalizePath(path.relative(process.cwd(), file)))}': async () => import('/@fs/${file}')`;
+    const ext = path.extname(file);
+    const relativePath = normalizePath(path.relative(process.cwd(), file));
+    if (!['.js', '.jsx', '.ts', '.tsx', '.mdx'].includes(ext)) {
+      logger.warn(`Cannot process ${ext} file with storyStoreV7: ${relativePath}`);
+    }
+
+    return `  '${toImportPath(relativePath)}': async () => import('/@fs/${file}')`;
   });
 
   return `

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -33,7 +33,8 @@
     "vue-docgen-api": "^4.40.0"
   },
   "peerDependencies": {
-    "@storybook/core-common": "^6.4.3",
+    "@storybook/core-common": ">=6.4.3 || >=6.5.0-alpha.0",
+    "@storybook/node-logger": ">=6.4.3 || >=6.5.0-alpha.0",
     "vite": ">=2.6.7"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,7 +2889,8 @@ __metadata:
     vite-plugin-mdx: ^3.5.6
     vue-docgen-api: ^4.40.0
   peerDependencies:
-    "@storybook/core-common": ^6.4.3
+    "@storybook/core-common": ">=6.4.3 || >=6.5.0-alpha.0"
+    "@storybook/node-logger": ">=6.4.3 || >=6.5.0-alpha.0"
     vite: ">=2.6.7"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This makes it a bit more obvious that something is wrong when using storyStoreV7 with `.svelte` files (ref https://github.com/storybookjs/builder-vite/issues/361), and gives an indication of how to fix the issue:

<img width="701" alt="image" src="https://user-images.githubusercontent.com/4616705/165955769-9f11e9c0-d666-40eb-b662-6051cb40ce62.png">

This also fixes https://github.com/storybookjs/builder-vite/issues/356 by expanding the range for the @storybook/core-common peer dependency to avoid installing an older version when the user is using a 6.5 pre-release.