### PR TITLE
Prevent vite:define from replacing in story source

### DIFF
--- a/examples/react-18/stories/EnvironmentVariables.jsx
+++ b/examples/react-18/stories/EnvironmentVariables.jsx
@@ -1,16 +1,20 @@
-export function EnvironmentVariables() {
+/* eslint-disable no-irregular-whitespace */
+
+export function EnvironmentVariables({ dynamic = '' }) {
   return (
     <div>
-      <h1>import . meta . env:</h1>
+      <h1>import​.meta​.env:</h1>
       <div>{JSON.stringify(import.meta.env, null, 2)}</div>
-      <h1>import . meta . env . STORYBOOK:</h1>
+      <h1>import​.meta​.env​.STORYBOOK:</h1>
       <div>{import.meta.env.STORYBOOK}</div>
-      <h1>import . meta . env . STORYBOOK_ENV_VAR:</h1>
+      <h1>import​.meta​.env​.STORYBOOK_ENV_VAR:</h1>
       <div>{import.meta.env.STORYBOOK_ENV_VAR}</div>
-      <h1>import . meta . env . VITE_ENV_VAR:</h1>
+      <h1>import​.meta​.env​.VITE_ENV_VAR:</h1>
       <div>{import.meta.env.VITE_ENV_VAR}</div>
-      <h1>import . meta . env . ENV_VAR:</h1>
+      <h1>import​.meta​.env​.ENV_VAR:</h1>
       <div>{import.meta.env.ENV_VAR}</div>
+      <h1>dynamic from props:</h1>
+      <div>{dynamic}</div>
     </div>
   );
 }

--- a/examples/react-18/stories/EnvironmentVariables.stories.jsx
+++ b/examples/react-18/stories/EnvironmentVariables.stories.jsx
@@ -5,4 +5,9 @@ export default {
   component: EnvironmentVariables,
 };
 
-export const Info = () => <EnvironmentVariables />;
+const Template = (args) => <EnvironmentVariables {...args} />;
+
+export const Info = Template.bind({});
+Info.args = {
+  dynamic: import.meta.env.VITE_ENV_VAR,
+};

--- a/examples/react-ts/.storybook/.babelrc
+++ b/examples/react-ts/.storybook/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
-}

--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -15,3 +15,5 @@ const config: StorybookViteConfig = {
     return config;
   },
 };
+
+export default config;

--- a/examples/react-ts/package.json
+++ b/examples/react-ts/package.json
@@ -28,6 +28,7 @@
     "http-server": "^14.1.0",
     "jest": "^27.5.1",
     "npm-run-all": "^4.1.5",
+    "ts-node": "^10.7.0",
     "typescript": "^4.5.4",
     "vite": "2.9.6",
     "wait-on": "^6.0.1"

--- a/examples/react-ts/stories/EnvironmentVariables.stories.tsx
+++ b/examples/react-ts/stories/EnvironmentVariables.stories.tsx
@@ -7,4 +7,9 @@ const meta: ComponentMeta<typeof EnvironmentVariables> = {
 };
 export default meta;
 
-export const Info = () => <EnvironmentVariables />;
+const Template = (args) => <EnvironmentVariables {...args} />;
+
+export const Info = Template.bind({});
+Info.args = {
+  dynamic: import.meta.env.VITE_ENV_VAR,
+};

--- a/examples/react-ts/stories/EnvironmentVariables.tsx
+++ b/examples/react-ts/stories/EnvironmentVariables.tsx
@@ -1,16 +1,20 @@
-export function EnvironmentVariables() {
+/* eslint-disable no-irregular-whitespace */
+
+export function EnvironmentVariables({ dynamic = '' }) {
   return (
     <div>
-      <h1>import . meta . env:</h1>
+      <h1>import​.meta​.env:</h1>
       <div>{JSON.stringify(import.meta.env, null, 2)}</div>
-      <h1>import . meta . env . STORYBOOK:</h1>
+      <h1>import​.meta​.env​.STORYBOOK:</h1>
       <div>{import.meta.env.STORYBOOK}</div>
-      <h1>import . meta . env . STORYBOOK_ENV_VAR:</h1>
+      <h1>import​.meta​.env​.STORYBOOK_ENV_VAR:</h1>
       <div>{import.meta.env.STORYBOOK_ENV_VAR}</div>
-      <h1>import . meta . env . VITE_ENV_VAR:</h1>
+      <h1>import​.meta​.env​.VITE_ENV_VAR:</h1>
       <div>{import.meta.env.VITE_ENV_VAR}</div>
-      <h1>import . meta . env . ENV_VAR:</h1>
+      <h1>import​.meta​.env​.ENV_VAR:</h1>
       <div>{import.meta.env.ENV_VAR}</div>
+      <h1>dynamic from props:</h1>
+      <div>{dynamic}</div>
     </div>
   );
 }

--- a/examples/react/stories/EnvironmentVariables.jsx
+++ b/examples/react/stories/EnvironmentVariables.jsx
@@ -1,16 +1,20 @@
-export function EnvironmentVariables() {
+/* eslint-disable no-irregular-whitespace */
+
+export function EnvironmentVariables({ dynamic = '' }) {
   return (
     <div>
-      <h1>import . meta . env:</h1>
+      <h1>import​.meta​.env:</h1>
       <div>{JSON.stringify(import.meta.env, null, 2)}</div>
-      <h1>import . meta . env . STORYBOOK:</h1>
+      <h1>import​.meta​.env​.STORYBOOK:</h1>
       <div>{import.meta.env.STORYBOOK}</div>
-      <h1>import . meta . env . STORYBOOK_ENV_VAR:</h1>
+      <h1>import​.meta​.env​.STORYBOOK_ENV_VAR:</h1>
       <div>{import.meta.env.STORYBOOK_ENV_VAR}</div>
-      <h1>import . meta . env . VITE_ENV_VAR:</h1>
+      <h1>import​.meta​.env​.VITE_ENV_VAR:</h1>
       <div>{import.meta.env.VITE_ENV_VAR}</div>
-      <h1>import . meta . env . ENV_VAR:</h1>
+      <h1>import​.meta​.env​.ENV_VAR:</h1>
       <div>{import.meta.env.ENV_VAR}</div>
+      <h1>dynamic from props:</h1>
+      <div>{dynamic}</div>
     </div>
   );
 }

--- a/examples/react/stories/EnvironmentVariables.stories.jsx
+++ b/examples/react/stories/EnvironmentVariables.stories.jsx
@@ -5,4 +5,9 @@ export default {
   component: EnvironmentVariables,
 };
 
-export const Info = () => <EnvironmentVariables />;
+const Template = (args) => <EnvironmentVariables {...args} />;
+
+export const Info = Template.bind({});
+Info.args = {
+  dynamic: import.meta.env.VITE_ENV_VAR,
+};

--- a/examples/svelte/.env
+++ b/examples/svelte/.env
@@ -1,0 +1,3 @@
+STORYBOOK_ENV_VAR=included
+VITE_ENV_VAR=included
+ENV_VAR=should_not_be_included

--- a/examples/svelte/stories/EnvironmentVariables.stories.svelte
+++ b/examples/svelte/stories/EnvironmentVariables.stories.svelte
@@ -8,8 +8,10 @@
   component={EnvironmentVariables}
 />
 
-<Template>
-  <EnvironmentVariables />
+<Template let:args>
+  <EnvironmentVariables {...args} />
 </Template>
 
-<Story name="Info" />
+<Story name="Info" args={{
+  dynamic: import.meta.env.VITE_ENV_VAR,
+}} />

--- a/examples/svelte/stories/EnvironmentVariables.svelte
+++ b/examples/svelte/stories/EnvironmentVariables.svelte
@@ -1,13 +1,16 @@
 <script>
   export const env = JSON.stringify(import.meta.env, null, 2);
   export const storybook = import.meta.env.STORYBOOK;
+  export let dynamic = '';
 </script>
 
 
 <div>
-  <h1>impor . meta . env:</h1>
+  <h1>impor​.meta​.env:</h1>
   <div>{env}</div>
-  <h1>import . meta . env . STORYBOOK:</h1>
+  <h1>import​.meta​.env​.STORYBOOK:</h1>
   <div>{storybook}</div>
+  <h1>dynamic:</h1>
+  <div>{dynamic}</div>
 </div>
 

--- a/examples/vue/.env
+++ b/examples/vue/.env
@@ -1,0 +1,3 @@
+STORYBOOK_ENV_VAR=included
+VITE_ENV_VAR=included
+ENV_VAR=should_not_be_included

--- a/examples/vue/stories/EnvironmentVariables.stories.js
+++ b/examples/vue/stories/EnvironmentVariables.stories.js
@@ -1,11 +1,22 @@
-import EnvironmentVariables from './EnvironmentVariables.vue';
+import EnvVars from './EnvironmentVariables.vue';
 
 export default {
   title: 'Environment Variables',
-  component: EnvironmentVariables,
+  component: EnvVars,
 };
 
-export const Info = () => ({
-  components: { EnvironmentVariables },
-  template: '<EnvironmentVariables />',
+const Template = (args) => ({
+  // Components used in your story `template` are defined in the `components` object
+  components: { EnvVars },
+  // The story's `args` need to be mapped into the template through the `setup()` method
+  setup() {
+    return { args };
+  },
+  // And then the `args` are bound to your component with `v-bind="args"`
+  template: '<env-vars v-bind="args" />',
 });
+
+export const Info = Template.bind({});
+Info.args = {
+  dynamic: import.meta.env.VITE_ENV_VAR,
+};

--- a/examples/vue/stories/EnvironmentVariables.vue
+++ b/examples/vue/stories/EnvironmentVariables.vue
@@ -1,15 +1,23 @@
 <template>
   <div>
-    <h1>import . meta . env:</h1>
+    <h1>import​.meta​.env:</h1>
     <div>{{ env }}</div>
-    <h1>import . meta . env . STORYBOOK:</h1>
+    <h1>import​.meta​.env​.STORYBOOK:</h1>
     <div>{{ storybook }}</div>
+    <h1>dynamic:</h1>
+    <div>{{ dynamic }}</div>
   </div>
 </template>
 
 <script>
 export default {
   name: 'env-vars',
+  props: {
+    dynamic: {
+      type: String,
+      required: true,
+    },
+  },
   computed: {
     env() {
       return JSON.stringify(import.meta.env, null, 2);

--- a/packages/builder-vite/build.ts
+++ b/packages/builder-vite/build.ts
@@ -7,7 +7,7 @@ import type { EnvsRaw, ExtendedOptions } from './types';
 export async function build(options: ExtendedOptions) {
   const { presets } = options;
 
-  const baseConfig = await commonConfig(options, 'development');
+  const baseConfig = await commonConfig(options, 'build');
   const config = {
     ...baseConfig,
     build: {

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -35,6 +35,7 @@
   "peerDependencies": {
     "@storybook/core-common": ">=6.4.3 || >=6.5.0-alpha.0",
     "@storybook/node-logger": ">=6.4.3 || >=6.5.0-alpha.0",
+    "@storybook/source-loader": ">=6.4.3 || >=6.5.0-alpha.0",
     "vite": ">=2.6.7"
   },
   "publishConfig": {

--- a/packages/builder-vite/source-loader-plugin.ts
+++ b/packages/builder-vite/source-loader-plugin.ts
@@ -1,21 +1,88 @@
 import sourceLoaderTransform from '@storybook/source-loader';
+import type { ExtendedOptions } from './types';
 
-export function sourceLoaderPlugin() {
-  return {
-    name: 'storybook-vite-source-loader-plugin',
-    enforce: 'pre',
-    async transform(src: string, id: string) {
-      if (id.match(/\.stories\.[jt]sx?$/)) {
-        // We need to mock 'this' when calling transform from @storybook/source-loader
-        // noinspection JSUnusedGlobalSymbols
-        const mockClassLoader = { emitWarning: (message: string) => console.warn(message), resourcePath: id };
-        const code = await sourceLoaderTransform.call(mockClassLoader, src);
+const storyPattern = /\.stories\.[jt]sx?$/;
+const storySourcePattern = /var __STORY__ = "(.*)"/;
+const storySourceReplacement = '--STORY_SOURCE_REPLACEMENT--';
 
-        return {
-          code,
-          map: { mappings: '' },
-        };
-      }
+const mockClassLoader = (id: string) => ({ emitWarning: (message: string) => console.warn(message), resourcePath: id });
+
+// HACK: Until we can support only node 15+ and use string.prototype.replaceAll
+const replaceAll = (str: string, search: string, replacement: string) => {
+  return str.split(search).join(replacement);
+};
+
+export function sourceLoaderPlugin(config: ExtendedOptions) {
+  if (config.configType === 'DEVELOPMENT') {
+    return {
+      name: 'storybook-vite-source-loader-plugin',
+      enforce: 'pre',
+      async transform(src: string, id: string) {
+        if (id.match(storyPattern)) {
+          const code = await sourceLoaderTransform.call(mockClassLoader(id), src);
+
+          return {
+            code,
+            map: { mappings: '' },
+          };
+        }
+      },
+    };
+  }
+
+  // In production, we need to be fancier, to avoid vite:define plugin from replacing values inside the `__STORY__` string
+  const storySources = new WeakMap<ExtendedOptions, Map<string, string>>();
+
+  return [
+    {
+      name: 'storybook-vite-source-loader-plugin',
+      enforce: 'pre',
+      buildStart() {
+        storySources.set(config, new Map());
+      },
+      async transform(src: string, id: string) {
+        if (id.match(storyPattern)) {
+          const code = await sourceLoaderTransform.call(mockClassLoader(id), src);
+          const [_, sourceString] = code.match(storySourcePattern) ?? [null, null];
+          if (sourceString) {
+            const map = storySources.get(config);
+            map?.set(id, sourceString);
+          }
+
+          // Remove story source so that it is not processed by vite:define plugin
+          const replacedCode = replaceAll(code, sourceString, storySourceReplacement);
+
+          return {
+            code: replacedCode,
+            map: { mappings: '' },
+          };
+        }
+      },
     },
-  };
+    {
+      name: 'storybook-vite-source-loader-plugin-post',
+      enforce: 'post',
+      buildStart() {
+        storySources.set(config, new Map());
+      },
+      async transform(src: string, id: string) {
+        if (id.match(storyPattern)) {
+          let code;
+          const map = storySources.get(config);
+          const storySourceStatement = map?.get(id);
+          // Put the previously-extracted source back in
+          if (storySourceStatement) {
+            code = replaceAll(src, storySourceReplacement, storySourceStatement);
+          } else {
+            code = src;
+          }
+
+          return {
+            code,
+            map: { mappings: '' },
+          };
+        }
+      },
+    },
+  ];
 }

--- a/packages/builder-vite/vite-config.ts
+++ b/packages/builder-vite/vite-config.ts
@@ -57,7 +57,7 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
   const plugins = [
     codeGeneratorPlugin(options),
     mockCoreJs(),
-    sourceLoaderPlugin(),
+    sourceLoaderPlugin(options),
     mdxPlugin(),
     noFouc(),
     injectExportOrderPlugin,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,6 +1601,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cspotcode/source-map-consumer@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@cspotcode/source-map-consumer@npm:0.8.0"
+  checksum: c0c16ca3d2f58898f1bd74c4f41a189dbcc202e642e60e489cbcc2e52419c4e89bdead02c886a12fb13ea37798ede9e562b2321df997ebc210ae9bd881561b4e
+  languageName: node
+  linkType: hard
+
+"@cspotcode/source-map-support@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@cspotcode/source-map-support@npm:0.7.0"
+  dependencies:
+    "@cspotcode/source-map-consumer": 0.8.0
+  checksum: 9faddda7757cd778b5fd6812137b2cc265810043680d6399acc20441668fafcdc874053be9dccd0d9110087287bfad27eb3bf342f72bceca9aa9059f5d0c4be8
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:^0.5.3":
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
@@ -4037,6 +4053,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.8
+  resolution: "@tsconfig/node10@npm:1.0.8"
+  checksum: b8d5fffbc6b17ef64ef74f7fdbccee02a809a063ade785c3648dae59406bc207f70ea2c4296f92749b33019fa36a5ae716e42e49cc7f1bbf0fd147be0d6b970a
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.9
+  resolution: "@tsconfig/node12@npm:1.0.9"
+  checksum: a01b2400ab3582b86b589c6d31dcd0c0656f333adecde85d6d7d4086adb059808b82692380bb169546d189bf771ae21d02544a75b57bd6da4a5dd95f8567bec9
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@tsconfig/node14@npm:1.0.1"
+  checksum: 976345e896c0f059867f94f8d0f6ddb8b1844fb62bf36b727de8a9a68f024857e5db97ed51d3325e23e0616a5e48c034ff51a8d595b3fe7e955f3587540489be
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@tsconfig/node16@npm:1.0.2"
+  checksum: ca94d3639714672bbfd55f03521d3f56bb6a25479bd425da81faf21f13e1e9d15f40f97377dedbbf477a5841c5b0c8f4cd1b391f33553d750b9202c54c2c07aa
+  languageName: node
+  linkType: hard
+
 "@tsconfig/svelte@npm:^3.0.0":
   version: 3.0.0
   resolution: "@tsconfig/svelte@npm:3.0.0"
@@ -5188,6 +5232,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.1.1":
+  version: 8.2.0
+  resolution: "acorn-walk@npm:8.2.0"
+  checksum: 1715e76c01dd7b2d4ca472f9c58968516a4899378a63ad5b6c2d668bba8da21a71976c14ec5f5b75f887b6317c4ae0b897ab141c831d741dc76024d8745f1ad1
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^6.4.1":
   version: 6.4.2
   resolution: "acorn@npm:6.4.2"
@@ -5493,6 +5544,13 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^3.6.0
   checksum: 348edfdd931b0b50868b55402c01c3f64df1d4c229ab6f063539a5025fd6c5f5bb8a0cab409bbed8d75d34762d22aa91b7c20b4204eb8177063158d9ba792981
+  languageName: node
+  linkType: hard
+
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
   languageName: node
   linkType: hard
 
@@ -7351,6 +7409,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^6.0.0, cross-spawn@npm:^6.0.5":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
@@ -7786,6 +7851,13 @@ __metadata:
   version: 27.5.1
   resolution: "diff-sequences@npm:27.5.1"
   checksum: a00db5554c9da7da225db2d2638d85f8e41124eccbd56cbaefb3b276dcbb1c1c2ad851c32defe2055a54a4806f030656cbf6638105fd6ce97bb87b90b32a33ca
+  languageName: node
+  linkType: hard
+
+"diff@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
   languageName: node
   linkType: hard
 
@@ -9088,6 +9160,7 @@ __metadata:
     npm-run-all: ^4.1.5
     react: ^16.4.14
     react-dom: ^16.4.14
+    ts-node: ^10.7.0
     typescript: ^4.5.4
     vite: 2.9.6
     wait-on: ^6.0.1
@@ -13012,6 +13085,13 @@ __metadata:
   dependencies:
     semver: ^6.0.0
   checksum: 484200020ab5a1fdf12f393fe5f385fc8e4378824c940fba1729dcd198ae4ff24867bc7a5646331e50cead8abff5d9270c456314386e629acec6dff4b8016b78
+  languageName: node
+  linkType: hard
+
+"make-error@npm:^1.1.1":
+  version: 1.3.6
+  resolution: "make-error@npm:1.3.6"
+  checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
   languageName: node
   linkType: hard
 
@@ -17787,6 +17867,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.7.0":
+  version: 10.7.0
+  resolution: "ts-node@npm:10.7.0"
+  dependencies:
+    "@cspotcode/source-map-support": 0.7.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.0
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 2a379e43f7478d0b79e1e63af91fe222d83857727957df4bd3bdf3c0a884de5097b12feb9bbf530074526b8874c0338b0e6328cf334f3a5e2c49c71e837273f7
+  languageName: node
+  linkType: hard
+
 "ts-pnp@npm:^1.1.6":
   version: 1.2.0
   resolution: "ts-pnp@npm:1.2.0"
@@ -18331,6 +18449,13 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"v8-compile-cache-lib@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
+  checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
   languageName: node
   linkType: hard
 
@@ -19280,6 +19405,13 @@ __metadata:
   dependencies:
     buffer-crc32: ~0.2.3
   checksum: daec5154b5485d8621bfea359e905ddca0b2f068430a4aa0a802bf5d67391157a383e0c2767acccbf5964264851da643bc740155a9458e2d8dce55b94c1cc2ed
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,6 +2907,7 @@ __metadata:
   peerDependencies:
     "@storybook/core-common": ">=6.4.3 || >=6.5.0-alpha.0"
     "@storybook/node-logger": ">=6.4.3 || >=6.5.0-alpha.0"
+    "@storybook/source-loader": ">=6.4.3 || >=6.5.0-alpha.0"
     vite: ">=2.6.7"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This fixes an issue where the vite:define plugin replaced environment variables inside the injected story source from `@storybook/source-loader`, which is supposed to be a string.  But when vite does the replacement, it adds its own quotes, which breaks the string.  

For a simplified example, storybook might generate something like this:
```js
var __STORY__ = "console.log(import.meta.env.VITE_VAR);"
```
But then vite:define turns it into:
```js
var __STORY__ = "console.log("env variable value");"
```

Here's a reproduction from the user who originally reported this issue: https://github.com/victorlmneves/vite-storybook

To test, I modified our environment variable stories.  In the process, I used some zero-width spaces to make the headings look a bit better, as suggested in https://vitejs.dev/guide/env-and-mode.html#production-replacement.

I also decided to use `ts-node` instead of adding a babel config for the react-ts project.  At least until we figure out exactly how that .babelrc works.  
