### PR TITLE
Use globalThis instead of global project

### DIFF
--- a/packages/builder-vite/codegen-set-addon-channel.ts
+++ b/packages/builder-vite/codegen-set-addon-channel.ts
@@ -1,6 +1,5 @@
 export function generateAddonSetupCode() {
   return `
-    import global from 'global';
     import createPostMessageChannel from '@storybook/channel-postmessage';
     import createWebSocketChannel from '@storybook/channel-websocket';
     import { addons } from '@storybook/addons';
@@ -9,7 +8,7 @@ export function generateAddonSetupCode() {
     addons.setChannel(channel);
     window.__STORYBOOK_ADDONS_CHANNEL__ = channel;
 
-    const { SERVER_CHANNEL_URL } = global;
+    const { SERVER_CHANNEL_URL } = globalThis;
     if (SERVER_CHANNEL_URL) {
       const serverChannel = createWebSocketChannel({ url: SERVER_CHANNEL_URL });
       addons.setServerChannel(serverChannel);


### PR DESCRIPTION
We were using `global` because it's installed with storybook, but that might change someday, and it causes problems in yarn pnp and probably pnpm as well, since we don't explicitly depend on it.  

Rather than add it to our dependencies, this just swaps it out for `globalThis` instead, which has good support aside from IE11, which vite doesn't support anyway.