### PR TITLE
Disable telemetry in examples

### DIFF
--- a/examples/lit-ts/.storybook/main.ts
+++ b/examples/lit-ts/.storybook/main.ts
@@ -6,6 +6,8 @@ module.exports = {
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite',
+    // we don't want to muck up the data when we're working on the builder
+    disableTelemetry: true,
   },
   framework: '@storybook/web-components',
   features: {

--- a/examples/react-18/.storybook/main.js
+++ b/examples/react-18/.storybook/main.js
@@ -4,6 +4,8 @@ module.exports = {
   addons: ['@storybook/addon-a11y', '@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite',
+    // we don't want to muck up the data when we're working on the builder
+    disableTelemetry: true,
   },
   features: {
     storyStoreV7: true,

--- a/examples/react-ts/.storybook/main.ts
+++ b/examples/react-ts/.storybook/main.ts
@@ -6,6 +6,8 @@ const config: StorybookViteConfig = {
   addons: ['@storybook/addon-a11y', '@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite',
+    // we don't want to muck up the data when we're working on the builder
+    disableTelemetry: true,
   },
   features: {
     storyStoreV7: true,

--- a/examples/react/.storybook/main.js
+++ b/examples/react/.storybook/main.js
@@ -4,6 +4,8 @@ module.exports = {
   addons: ['@storybook/addon-a11y', '@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite',
+    // we don't want to muck up the data when we're working on the builder
+    disableTelemetry: true,
   },
   features: {
     storyStoreV7: false,

--- a/examples/svelte/.storybook/main.js
+++ b/examples/svelte/.storybook/main.js
@@ -6,6 +6,8 @@ module.exports = {
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-svelte-csf'],
   core: {
     builder: '@storybook/builder-vite',
+    // we don't want to muck up the data when we're working on the builder
+    disableTelemetry: true,
   },
   features: {
     // On-demand store does not work for .svelte stories, only CSF.

--- a/examples/vue/.storybook/main.js
+++ b/examples/vue/.storybook/main.js
@@ -4,6 +4,8 @@ module.exports = {
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite',
+    // we don't want to muck up the data when we're working on the builder
+    disableTelemetry: true,
   },
   async viteFinal(config, { configType }) {
     // customize the Vite config here

--- a/examples/workspaces/packages/catalog/.storybook/main.js
+++ b/examples/workspaces/packages/catalog/.storybook/main.js
@@ -7,6 +7,8 @@ module.exports = {
   addons: ['@storybook/addon-a11y', '@storybook/addon-links', '@storybook/addon-essentials'],
   core: {
     builder: '@storybook/builder-vite',
+    // we don't want to muck up the data when we're working on the builder
+    disableTelemetry: true,
   },
   features: {
     storyStoreV7: true,


### PR DESCRIPTION
I realized that when we're futzing around with developing the builder, we're probably sending telemetry data that will distort the priority of real issues that users are having in their projects.  So, I've disabled telemetry for the examples, and added a note so that hopefully users don't just copy and paste our example configs with disabled telemetry.