### PR TITLE
Allow setting global args in SB 6.5+

### DIFF
--- a/examples/react-ts/.storybook/preview.ts
+++ b/examples/react-ts/.storybook/preview.ts
@@ -7,3 +7,7 @@ export const parameters = {
     },
   },
 };
+
+export const argTypes = { globalArg: { options: ['A', 'B'], control: 'select' } };
+
+export const args = { globalArg: 'A' };

--- a/examples/react-ts/README.md
+++ b/examples/react-ts/README.md
@@ -1,3 +1,5 @@
 # React TypesScript
 
 This example demonstrates storybook in a React v16 project using TypeScript.
+
+It also uses the v7 story store, and demonstrates the use of global args.

--- a/examples/react/.storybook/preview.js
+++ b/examples/react/.storybook/preview.js
@@ -7,3 +7,7 @@ export const parameters = {
     },
   },
 };
+
+export const argTypes = { globalArg: { options: ['A', 'B'], control: 'select' } };
+
+export const args = { globalArg: 'A' };

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -3,3 +3,5 @@
 This example demonstrates storybook in a React v16 project.
 
 It uses autotitle for some stories, but without a configuration object, a `titlePrefix` cannot be defined.
+
+This example also demonstrates global arg configuration in a v6 story store project.

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -40,7 +40,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
     const configs = [${importArray('config', configEntries.length).concat('preview.default').join(',')}].filter(Boolean)
 
     configs.forEach(config => {
-      Object.keys(config).forEach(async (key) => {
+      Object.keys(config).forEach((key) => {
         const value = config[key];
         switch (key) {
           case 'args': {

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -22,44 +22,43 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
     // is loaded. That way our client-apis can assume the existence of the API+store
     import { configure } from '${frameworkImportPath}';
 
-    import {
-      addDecorator,
-      addParameters,
-      addLoader,
-      addArgTypesEnhancer,
-      addArgsEnhancer,
-      setGlobalRender
-    } from '@storybook/client-api';
+    import * as clientApi from "@storybook/client-api";
     import { logger } from '@storybook/client-logger';
     ${absoluteFilesToImport(configEntries, 'config')}
     import * as preview from '${virtualPreviewFile}';
     import { configStories } from '${virtualStoriesFile}';
 
-    const configs = [${importArray('config', configEntries.length).concat('preview.default').join(',')}].filter(Boolean)
+    const {
+      addDecorator,
+      addParameters,
+      addLoader,
+      addArgTypesEnhancer,
+      addArgsEnhancer,
+      setGlobalRender,
+    } = clientApi;
 
-    try {
-      // these were added in 6.5, but we support 6.4 as well.
-      var {addArgs, addArgTypes} = await import('@storybook/client-api');
-    } catch (err) {
-      // ignore error
-    }
+    const configs = [${importArray('config', configEntries.length).concat('preview.default').join(',')}].filter(Boolean)
 
     configs.forEach(config => {
       Object.keys(config).forEach(async (key) => {
         const value = config[key];
         switch (key) {
           case 'args': {
-            if (typeof addArgs !== 'undefined') {
-              return addArgs(value);
+            if (typeof clientApi.addArgs !== "undefined") {
+              return clientApi.addArgs(value);
             } else {
-              return logger.warn('Could not add global args. Please open an issue in storybookjs/builder-vite.');
+              return logger.warn(
+                "Could not add global args. Please open an issue in storybookjs/builder-vite."
+              );
             }
           }
           case 'argTypes': {
-            if (typeof addArgTypes !== 'undefined') {
-              return addArgTypes(value);
+            if (typeof clientApi.addArgTypes !== "undefined") {
+              return clientApi.addArgTypes(value);
             } else {
-              return logger.warn('Could not add global argTypes. Please open an issue in storybookjs/builder-vite.');
+              return logger.warn(
+                "Could not add global argTypes. Please open an issue in storybookjs/builder-vite."
+              );
             }
           }
           case 'decorators': {


### PR DESCRIPTION
Fixes https://github.com/storybookjs/builder-vite/issues/395.

This is a little bit tricky to do in a way that supports storybook 6.4 and 6.5.  I've used a dynamic `import()` and a top-level await, in order to wrap the import of the new methods in a try/catch.  This has _decent_ [browser support](https://caniuse.com/mdn-javascript_operators_await_top_level), but is not universal.  Curious if anyone else has another idea.

I've added example global args in the `react` and `react-ts` examples, to show both story store V6 and V7 support.  You can simulate storybook 6.4 by changing the destructured imports to `addArgsZ` and `addArgTypesZ`, building, and starting an example.  You shouldn't see the control, and there shouldn't be any console errors.