### PR TITLE
fix: prevent crashing on "--smoke-test"

### DIFF
--- a/packages/builder-vite/index.ts
+++ b/packages/builder-vite/index.ts
@@ -11,7 +11,8 @@ import type { RequestHandler, Request, Response } from 'express';
 import type { InlineConfig, UserConfig, ViteDevServer } from 'vite';
 import type { ExtendedOptions } from './types';
 
-export interface ViteStats {}
+// Storybook's Stats are optional Webpack related property
+export type ViteStats = null;
 
 export type ViteBuilder = Builder<UserConfig, ViteStats>;
 
@@ -68,7 +69,7 @@ export const start: ViteBuilder['start'] = async ({ startTime, options, router, 
 
   return {
     bail,
-    stats: {} as ViteStats,
+    stats: null,
     totalTime: process.hrtime(startTime),
   };
 };


### PR DESCRIPTION
Fixes #397.

Storybook expects `stats` to match `Stats` interface of `webpack`: https://github.com/webpack/webpack/blob/main/types.d.ts#L11243-L11253.

This type-mismatch is caused by `@storybook/core-common`'s `Builder` and will be fixed by https://github.com/storybookjs/storybook/pull/18377.