### PR TITLE
Support missing import.meta.env

### DIFF
--- a/packages/builder-vite/envs.ts
+++ b/packages/builder-vite/envs.ts
@@ -45,6 +45,9 @@ export function stringifyProcessEnvs(raw: EnvsRaw, envPrefix: UserConfig['envPre
   // support destructuring like
   // const { foo } = import.meta.env;
   envs['import.meta.env'] = JSON.stringify(stringifyEnvs(updatedRaw));
+  // Prevent build breaking on a missing var, similar to vite
+  // @see https://github.com/vitejs/vite/blob/908c9e4cdd2cceb0f01495e38066ffe33c21ddb8/packages/vite/src/node/plugins/define.ts#L50
+  envs['import.meta.env.'] = '({}).';
 
   return envs;
 }


### PR DESCRIPTION
Currently vite storybook builder breaks when any env var used in code via `import.meta.env` is missing while building storybooks.

Apparently that happens because Rollup does direct inline replacements and turns code like

```ts
const getMyVar = () => import.meta.env.VITE_MISSING_VAR === 'true'
```

into something like

```js
const getMyVar = () => {"BASE_URL":"/","MODE":"production","DEV":false,"PROD":true}.VITE_MISSING_VAR === "true";
```

which is syntactically incorrect.
See my reproduction repo for an example — https://github.com/princed/vite-sb-meta-env-repro. 

To mitigate this `vite` itself [adds a replacement](https://github.com/vitejs/vite/blob/908c9e4cdd2cceb0f01495e38066ffe33c21ddb8/packages/vite/src/node/plugins/define.ts#L50) from `import.meta.env.` to `({}).` to catch missing direct replacements and produce correct code. I opted for identical solution here.

A similar workaround is also possible on the user side:

```js
async viteFinal(config) {
    config.define = {
      'import.meta.env.': `({}).`,
    };
   return config; 
}