### PR TITLE
Allow vite 3 alpha version.

### DIFF
--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -37,7 +37,7 @@
     "@storybook/core-common": ">=6.4.3 || >=6.5.0-alpha.0",
     "@storybook/node-logger": ">=6.4.3 || >=6.5.0-alpha.0",
     "@storybook/source-loader": ">=6.4.3 || >=6.5.0-alpha.0",
-    "vite": ">=2.6.7"
+    "vite": ">=2.6.7 || >=3.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Allow vite 3 alpha version at user own risk.

Current npm error:

```
npm ERR! Found: vite@3.0.0-alpha.13
npm ERR! node_modules/vite
npm ERR!   dev vite@"^3.0.0-alpha.13" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer vite@">=2.6.7" from @storybook/builder-vite@0.1.36
npm ERR! node_modules/@storybook/builder-vite
npm ERR!   dev @storybook/builder-vite@"^0.1.36" from the root project
```