### PR TITLE
Handle resolve.alias as an array

### DIFF
--- a/examples/vue/.storybook/main.ts
+++ b/examples/vue/.storybook/main.ts
@@ -1,3 +1,6 @@
+const { resolve } = require('path');
+const { mergeConfig } = require('vite');
+
 export default {
   framework: '@storybook/vue3',
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -11,7 +14,9 @@ export default {
     previewMdx2: true,
   },
   async viteFinal(config, { configType }) {
-    // customize the Vite config here
-    return config;
+    // Demonstrates use of mergeConfig and resolve.alias as an array
+    return mergeConfig(config, {
+      resolve: { alias: [{ find: '@assets', replacement: resolve(__dirname, '..', 'stories', 'assets') }] },
+    });
   },
 };

--- a/examples/vue/stories/Introduction.stories.mdx
+++ b/examples/vue/stories/Introduction.stories.mdx
@@ -1,12 +1,12 @@
 import { Meta } from '@storybook/addon-docs';
-import Code from './assets/code-brackets.svg';
-import Colors from './assets/colors.svg';
-import Comments from './assets/comments.svg';
-import Direction from './assets/direction.svg';
-import Flow from './assets/flow.svg';
-import Plugin from './assets/plugin.svg';
-import Repo from './assets/repo.svg';
-import StackAlt from './assets/stackalt.svg';
+import Code from '@assets/code-brackets.svg';
+import Colors from '@assets/colors.svg';
+import Comments from '@assets/comments.svg';
+import Direction from '@assets/direction.svg';
+import Flow from '@assets/flow.svg';
+import Plugin from '@assets/plugin.svg';
+import Repo from '@assets/repo.svg';
+import StackAlt from '@assets/stackalt.svg';
 
 <Meta title="Introduction" />
 

--- a/packages/builder-vite/code-generator-plugin.ts
+++ b/packages/builder-vite/code-generator-plugin.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { mergeConfig } from 'vite';
 import { transformIframeHtml } from './transform-iframe-html';
 import { generateIframeScriptCode } from './codegen-iframe-script';
 import { generateModernIframeScriptCode } from './codegen-modern-iframe-script';
@@ -64,13 +65,11 @@ export function codeGeneratorPlugin(options: ExtendedOptions): Plugin {
         require.resolve('react-dom/client', { paths: [config.root || process.cwd()] });
       } catch (e) {
         if (isNodeError(e) && e.code === 'MODULE_NOT_FOUND') {
-          config.resolve = {
-            ...config.resolve,
+          config.resolve = mergeConfig(config.resolve ?? {}, {
             alias: {
-              ...config.resolve?.alias,
               'react-dom/client': path.resolve(__dirname, '..', 'input', 'react-dom-client-placeholder.js'),
             },
-          };
+          });
         }
       }
     },


### PR DESCRIPTION
Fixes #425.

We weren't being smart enough about merging in the `resolve.alias` config, which can either be an object or an array.  So, I've used `mergeConfig` from vite to handle that instead, and added a demonstration in the vue example that fails without this change but works with it.

@rlesniak, how's this look to you?