### PR TITLE
Improve sourcemaps

### DIFF
--- a/packages/builder-vite/inject-export-order-plugin.ts
+++ b/packages/builder-vite/inject-export-order-plugin.ts
@@ -1,4 +1,5 @@
 import { parse } from 'es-module-lexer';
+import MagicString from 'magic-string';
 
 export const injectExportOrderPlugin = {
   name: 'storybook-vite-inject-export-order-plugin',
@@ -17,12 +18,12 @@ export const injectExportOrderPlugin = {
       // user has defined named exports already
       return;
     }
-
+    const s = new MagicString(code);
     const orderedExports = exports.filter((e) => e !== 'default');
-
+    s.append(`;export const __namedExportsOrder = ${JSON.stringify(orderedExports)};`);
     return {
-      code: `${code};\nexport const __namedExportsOrder = ${JSON.stringify(orderedExports)};`,
-      map: null,
+      code: s.toString(),
+      map: s.generateMap({ hires: true, source: id }),
     };
   },
 };

--- a/packages/builder-vite/plugins/react-docgen.ts
+++ b/packages/builder-vite/plugins/react-docgen.ts
@@ -51,7 +51,7 @@ export function reactDocgen({ include = /\.(mjs|tsx?|jsx?)$/, exclude = [/node_m
 
         return {
           code: s.toString(),
-          map: s.generateMap(),
+          map: s.generateMap({ hires: true, source: id }),
         };
       } catch (e) {
         // Usually this is just an error from react-docgen that it couldn't find a component

--- a/packages/builder-vite/plugins/svelte-docgen.ts
+++ b/packages/builder-vite/plugins/svelte-docgen.ts
@@ -89,7 +89,7 @@ export function svelteDocgen(svelteOptions: Record<string, any>): Plugin {
 
         return {
           code: s.toString(),
-          map: s.generateMap(),
+          map: s.generateMap({ hires: true, source: id }),
         };
       }
     },

--- a/packages/builder-vite/plugins/vue-docgen.ts
+++ b/packages/builder-vite/plugins/vue-docgen.ts
@@ -15,7 +15,7 @@ export function vueDocgen(): Plugin {
 
         return {
           code: s.toString(),
-          map: s.generateMap(),
+          map: s.generateMap({ hires: true, source: id }),
         };
       }
     },


### PR DESCRIPTION
Turns out we weren't creating good sourcemaps, especially in dev.  It seems that whereas rollup only uses the `mappings`, I guess that vite/esbuild uses the `sources` field of the sourcemap as well, and without passing the `source` option to MagicString's `generateMap`, we were losing the connection.  So, this adds the `id` as the source, and also enables `hires` (high resolution) so that columns are correct and not just lines (useful for code coverage, for example).

I also added MagicString to some of our other plugins which weren't using it.

The most obvious changes are in the react and svelte projects.  Vue is a bit improved, but we're still losing the story file sourcemaps for some reason.

To test, fire up an example project (in dev especially, but good to check prod builds too), look in the sources tab in devtools, and poke around, looking for sourcemapped versions of the files.  You should see them in this branch, but not nearly as many, if any, in main.  

@yannbf, I also tested these changes by copying the `dist` folder from this project into the node_modules of your https://github.com/yannbf/storybook-coverage-recipes project, and got good results from the react_vite and svelte_vite examples there.