### PR TITLE
Ignore applyDecorators in v6 story store

### DIFF
--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -85,6 +85,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
             v[key] = value;
             return addParameters(v, false);
           }
+          case 'decorateStory':
           case 'applyDecorators':
           case 'renderToDOM': {
             return null; // This key is not handled directly in v6 mode.

--- a/packages/builder-vite/codegen-iframe-script.ts
+++ b/packages/builder-vite/codegen-iframe-script.ts
@@ -85,7 +85,7 @@ export async function generateIframeScriptCode(options: ExtendedOptions) {
             v[key] = value;
             return addParameters(v, false);
           }
-          case 'decorateStory':
+          case 'applyDecorators':
           case 'renderToDOM': {
             return null; // This key is not handled directly in v6 mode.
           }


### PR DESCRIPTION
In https://github.com/storybookjs/storybook/commit/fcb61e10a3fb0ef5c59137c09c7766699a309b14 `decorateStory` was renamed by @yannbf to `applyDecorators` but the same author didn't think to rename potential references leading to a `applyDecorators was not supported :( !` log and I assume decorators not being applied when using Storybook. This pull request aims to solve the issue.