### PR TITLE
Cleanup `peerDependencies`

### DIFF
--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/storybookjs/builder-vite/#readme",
   "dependencies": {
     "@joshwooding/vite-plugin-react-docgen-typescript": "0.0.4",
-    "@storybook/mdx1-csf": "^0.0.4",
+    "@storybook/node-logger": ">=6.4.3",
     "@storybook/source-loader": "^6.4.3",
     "@vitejs/plugin-react": "^2.0.0",
     "ast-types": "^0.14.2",
@@ -27,6 +27,7 @@
     "sveltedoc-parser": "^4.2.1"
   },
   "devDependencies": {
+    "@storybook/mdx1-csf": "^0.0.4",
     "@storybook/mdx2-csf": "^0.0.3",
     "@sveltejs/vite-plugin-svelte": "^1.0.0",
     "@types/express": "^4.17.13",
@@ -34,10 +35,7 @@
     "vue-docgen-api": "^4.40.0"
   },
   "peerDependencies": {
-    "@storybook/core-common": ">=6.4.3",
     "@storybook/mdx2-csf": "^0.0.3",
-    "@storybook/node-logger": ">=6.4.3",
-    "@storybook/source-loader": ">=6.4.3",
     "vite": ">= 3.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -14,8 +14,9 @@
   "homepage": "https://github.com/storybookjs/builder-vite/#readme",
   "dependencies": {
     "@joshwooding/vite-plugin-react-docgen-typescript": "0.0.4",
+    "@storybook/core-common": "^6.4.3",
     "@storybook/mdx1-csf": "^0.0.4",
-    "@storybook/node-logger": ">=6.4.3",
+    "@storybook/node-logger": "^6.4.3",
     "@storybook/source-loader": "^6.4.3",
     "@vitejs/plugin-react": "^2.0.0",
     "ast-types": "^0.14.2",

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/storybookjs/builder-vite/#readme",
   "dependencies": {
     "@joshwooding/vite-plugin-react-docgen-typescript": "0.0.4",
+    "@storybook/mdx1-csf": "^0.0.4",
     "@storybook/node-logger": ">=6.4.3",
     "@storybook/source-loader": "^6.4.3",
     "@vitejs/plugin-react": "^2.0.0",
@@ -27,7 +28,6 @@
     "sveltedoc-parser": "^4.2.1"
   },
   "devDependencies": {
-    "@storybook/mdx1-csf": "^0.0.4",
     "@storybook/mdx2-csf": "^0.0.3",
     "@sveltejs/vite-plugin-svelte": "^1.0.0",
     "@types/express": "^4.17.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,9 +2857,10 @@ __metadata:
   resolution: "@storybook/builder-vite@workspace:packages/builder-vite"
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.0.4
+    "@storybook/core-common": ^6.4.3
     "@storybook/mdx1-csf": ^0.0.4
     "@storybook/mdx2-csf": ^0.0.3
-    "@storybook/node-logger": ">=6.4.3"
+    "@storybook/node-logger": ^6.4.3
     "@storybook/source-loader": ^6.4.3
     "@sveltejs/vite-plugin-svelte": ^1.0.0
     "@types/express": ^4.17.13
@@ -3080,7 +3081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/core-common@npm:6.5.9":
+"@storybook/core-common@npm:6.5.9, @storybook/core-common@npm:^6.4.3":
   version: 6.5.9
   resolution: "@storybook/core-common@npm:6.5.9"
   dependencies:
@@ -3401,7 +3402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/node-logger@npm:6.5.9, @storybook/node-logger@npm:>=6.4.3":
+"@storybook/node-logger@npm:6.5.9, @storybook/node-logger@npm:^6.4.3":
   version: 6.5.9
   resolution: "@storybook/node-logger@npm:6.5.9"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,6 +2859,7 @@ __metadata:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.0.4
     "@storybook/mdx1-csf": ^0.0.4
     "@storybook/mdx2-csf": ^0.0.3
+    "@storybook/node-logger": ">=6.4.3"
     "@storybook/source-loader": ^6.4.3
     "@sveltejs/vite-plugin-svelte": ^1.0.0
     "@types/express": ^4.17.13
@@ -2874,10 +2875,7 @@ __metadata:
     sveltedoc-parser: ^4.2.1
     vue-docgen-api: ^4.40.0
   peerDependencies:
-    "@storybook/core-common": ">=6.4.3"
     "@storybook/mdx2-csf": ^0.0.3
-    "@storybook/node-logger": ">=6.4.3"
-    "@storybook/source-loader": ">=6.4.3"
     vite: ">= 3.0.0"
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
@@ -3403,7 +3401,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/node-logger@npm:6.5.9":
+"@storybook/node-logger@npm:6.5.9, @storybook/node-logger@npm:>=6.4.3":
   version: 6.5.9
   resolution: "@storybook/node-logger@npm:6.5.9"
   dependencies:


### PR DESCRIPTION
@storybook/source-loader doesn't need to be in peerDependencies because it's already in dependencies

@storybook/core-common and @storybook/node-logger can be just regular dependencies instead of peerDependencies since we don't need the user to add them to their package.json

~~@storybook/mdx1-csf doesn't need to be downloaded by all users. Users will use either @storybook/mdx1-csf or @storybook/mdx2-csf so move it to devDependencies so that users won't end up including it automatically~~