### PR TITLE
Set vite `appType` to "custom"

### DIFF
--- a/packages/builder-vite/vite-server.ts
+++ b/packages/builder-vite/vite-server.ts
@@ -14,6 +14,7 @@ export async function createViteServer(options: ExtendedOptions, devServer: Serv
     ...baseConfig,
     server: {
       middlewareMode: true,
+      appType: 'custom',
       hmr: {
         port,
         server: devServer,


### PR DESCRIPTION
Fixes https://github.com/storybookjs/builder-vite/issues/446

To test this out, clone https://github.com/SamuelPoulin/vite-react-typescript-storybook-minimal and install dependencies, make this change in node_modules, and verify that `yarn storybook` launches storybook and not the app. 

This is a new setting that was added in Vite 3: https://vitejs.dev/config/shared-options.html#apptype.