### PR TITLE
Improve react docgen plugin usage

### DIFF
--- a/packages/builder-vite/plugins/react-docgen.ts
+++ b/packages/builder-vite/plugins/react-docgen.ts
@@ -24,7 +24,10 @@ type Options = {
   exclude?: string | RegExp | (string | RegExp)[];
 };
 
-export function reactDocgen({ include = /\.(mjs|tsx?|jsx?)$/, exclude = [/node_modules\/.*/] }: Options = {}): Plugin {
+export function reactDocgen({
+  include = /\.(mjs|tsx?|jsx?)$/,
+  exclude = [/node_modules\/.*/, '**/**.stories.tsx'],
+}: Options = {}): Plugin {
   const cwd = process.cwd();
   const filter = createFilter(include, exclude);
 


### PR DESCRIPTION
Fixes https://github.com/storybookjs/builder-vite/issues/456

This uses the same approach as [storybook itself](https://github.com/storybookjs/storybook/blob/de561458b3e6e9f416cc407be71a18618caafc84/presets/react-webpack/src/framework-preset-react-docs.ts).  The `react-docgen` plugin is used as long as the option is not set to `false` (previously we did not respect that), and it is used on all files unless the option is set to `react-docgen-typescript`, in which case it does not run on typescript files, and leaves those to the other plugin.  

This also includes a change to always set `savePropValueAsString` on the typescript plugin, as storybook does, even though from what I can tell, storybook is fine even when it's set to false.  But, it seems worth it to match storybook to avoid any subtle bugs or corner cases it might be intended to prevent.