### PR TITLE
Remove pluginutils from dependencies

### DIFF
--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -14,7 +14,6 @@
   "homepage": "https://github.com/storybookjs/builder-vite/#readme",
   "dependencies": {
     "@joshwooding/vite-plugin-react-docgen-typescript": "0.0.5",
-    "@rollup/pluginutils": "^4.2.1",
     "@storybook/core-common": "^6.4.3",
     "@storybook/mdx1-csf": "^0.0.4",
     "@storybook/node-logger": "^6.4.3",

--- a/packages/builder-vite/plugins/react-docgen.ts
+++ b/packages/builder-vite/plugins/react-docgen.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { createFilter } from '@rollup/pluginutils';
 import {
   parse,
   handlers as docgenHandlers,
@@ -9,6 +8,7 @@ import {
 import type { DocumentationObject } from 'react-docgen/lib/Documentation';
 import MagicString from 'magic-string';
 import type { Plugin } from 'vite';
+import { createFilter } from 'vite';
 import actualNameHandler from './docgen-handlers/actualNameHandler';
 
 type DocObj = DocumentationObject & { actualName: string };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2873,7 +2873,6 @@ __metadata:
   resolution: "@storybook/builder-vite@workspace:packages/builder-vite"
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.0.5
-    "@rollup/pluginutils": ^4.2.1
     "@storybook/core-common": ^6.4.3
     "@storybook/mdx1-csf": ^0.0.4
     "@storybook/mdx2-csf": ^0.0.3


### PR DESCRIPTION
Hi. A small fix here 👍 

I've removed `@rollup/pluginutils` from the dependencies list because `createFilter` util is exposed from Vite v3. (vite >= 3 is in the peer deps, so it's safe)
Less dependencies are better.

- https://github.com/vitejs/vite/pull/8562
- #459 