### PR TITLE
Rename Storybook root IDs for v7 compatibility

### DIFF
--- a/packages/builder-vite/input/iframe.html
+++ b/packages/builder-vite/input/iframe.html
@@ -22,8 +22,8 @@
   </head>
   <body>
     <!-- [BODY HTML SNIPPET HERE] -->
-    <div id="root"></div>
-    <div id="docs-root"></div>
+    <div id="storybook-root"></div>
+    <div id="storybook-docs"></div>
     <script type="module" src="/virtual:/@storybook/builder-vite/vite-app.js"></script>
   </body>
 </html>

--- a/packages/builder-vite/plugins/no-fouc.ts
+++ b/packages/builder-vite/plugins/no-fouc.ts
@@ -43,8 +43,8 @@ function insertHeadStyles(html: string) {
     :not(.sb-show-errordisplay) > .sb-errordisplay {
       display: none;
     }
-    #root[hidden],
-    #docs-root[hidden] {
+    #storybook-root[hidden],
+    #storybook-docs[hidden] {
       display: none !important;
     }
   </style>


### PR DESCRIPTION
Storybook v7 introduces a breaking change which renames the root elements that are selected during story rendering. This results in the following error when running `sb dev`:

```
TypeError: Cannot read properties of null (reading 'setAttribute')
    at WebView.showStory (http://localhost:6006/node_modules/.vite-storybook/deps/chunk-FSTL3CDP.js?v=bad8a373:1166:20)
    at WebView.prepareForStory (http://localhost:6006/node_modules/.vite-storybook/deps/chunk-FSTL3CDP.js?v=bad8a373:1075:10)
    at PreviewWeb.renderSelection (http://localhost:6006/node_modules/.vite-storybook/deps/chunk-FSTL3CDP.js?v=bad8a373:1609:52)
    at async PreviewWeb.selectSpecifiedStory (http://localhost:6006/node_modules/.vite-storybook/deps/chunk-FSTL3CDP.js?v=bad8a373:1408:5)
```

Which is triggered by this: https://github.com/storybookjs/storybook/blob/next/code/lib/preview-web/src/WebView.ts#L180-L183.

See https://github.com/storybookjs/storybook/pull/10638 for more information.