### PR TITLE
fix: add missing peer deps

### DIFF
--- a/examples/lit-ts/yarn.lock
+++ b/examples/lit-ts/yarn.lock
@@ -2627,9 +2627,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/examples/preact/yarn.lock
+++ b/examples/preact/yarn.lock
@@ -2650,9 +2650,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/examples/react-18/yarn.lock
+++ b/examples/react-18/yarn.lock
@@ -2706,9 +2706,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/examples/react-ts/yarn.lock
+++ b/examples/react-ts/yarn.lock
@@ -2725,9 +2725,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/examples/react/yarn.lock
+++ b/examples/react/yarn.lock
@@ -2731,9 +2731,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/examples/svelte/yarn.lock
+++ b/examples/svelte/yarn.lock
@@ -2636,9 +2636,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/examples/vue2.6/yarn.lock
+++ b/examples/vue2.6/yarn.lock
@@ -2724,9 +2724,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/examples/vue2.7/yarn.lock
+++ b/examples/vue2.7/yarn.lock
@@ -2724,9 +2724,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/examples/vue3/yarn.lock
+++ b/examples/vue3/yarn.lock
@@ -2889,9 +2889,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/examples/workspaces/yarn.lock
+++ b/examples/workspaces/yarn.lock
@@ -2706,9 +2706,18 @@ __metadata:
     sveltedoc-parser: ^4.2.1
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: node
   linkType: soft

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -69,6 +69,7 @@
     "@storybook/mdx2-csf": "^0.0.3",
     "@sveltejs/vite-plugin-svelte": "^1.0.0",
     "@vitejs/plugin-vue": "^3.0.0",
+    "vue-docgen-api": "^4.40.0",
     "vite": ">= 3.0.0"
   },
   "peerDependenciesMeta": {
@@ -76,6 +77,9 @@
       "optional": true
     },
     "@sveltejs/vite-plugin-svelte": {
+      "optional": true
+    },
+    "vue-docgen-api": {
       "optional": true
     },
     "@vitejs/plugin-vue": {

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -67,10 +67,18 @@
   },
   "peerDependencies": {
     "@storybook/mdx2-csf": "^0.0.3",
+    "@sveltejs/vite-plugin-svelte": "^1.0.0",
+    "@vitejs/plugin-vue": "^3.0.0",
     "vite": ">= 3.0.0"
   },
   "peerDependenciesMeta": {
     "@storybook/mdx2-csf": {
+      "optional": true
+    },
+    "@sveltejs/vite-plugin-svelte": {
+      "optional": true
+    },
+    "@vitejs/plugin-vue": {
       "optional": true
     }
   },

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -69,8 +69,8 @@
     "@storybook/mdx2-csf": "^0.0.3",
     "@sveltejs/vite-plugin-svelte": "^1.0.0",
     "@vitejs/plugin-vue": "^3.0.0",
-    "vue-docgen-api": "^4.40.0",
-    "vite": ">= 3.0.0"
+    "vite": ">= 3.0.0",
+    "vue-docgen-api": "^4.40.0"
   },
   "peerDependenciesMeta": {
     "@storybook/mdx2-csf": {
@@ -79,10 +79,10 @@
     "@sveltejs/vite-plugin-svelte": {
       "optional": true
     },
-    "vue-docgen-api": {
+    "@vitejs/plugin-vue": {
       "optional": true
     },
-    "@vitejs/plugin-vue": {
+    "vue-docgen-api": {
       "optional": true
     }
   },

--- a/packages/builder-vite/vite-config.ts
+++ b/packages/builder-vite/vite-config.ts
@@ -133,7 +133,7 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
 
     try {
       const { vueDocgen } = await import('./plugins/vue-docgen');
-      plugins.push(vueDocgen(3);
+      plugins.push(vueDocgen(3));
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
         throw new Error(

--- a/packages/builder-vite/vite-config.ts
+++ b/packages/builder-vite/vite-config.ts
@@ -91,8 +91,6 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
     try {
       const vuePlugin = is27 ? require('@vitejs/plugin-vue2') : require('vite-plugin-vue2').createVuePlugin;
       plugins.push(vuePlugin());
-      const { vueDocgen } = await import('./plugins/vue-docgen');
-      plugins.push(vueDocgen(2));
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
         throw new Error(`
@@ -104,20 +102,45 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
       }
       throw err;
     }
+    try {
+      const { vueDocgen } = await import('./plugins/vue-docgen');
+      plugins.push(vueDocgen(2));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
+        throw new Error(
+          '@storybook/builder-vite requires vue-docgen-api to be installed ' +
+            'when using @storybook/vue.' +
+            '  Please install it and start storybook again.'
+        );
+      }
+      throw err;
+    }
   }
 
   if (framework === 'vue3') {
     try {
       const vuePlugin = require('@vitejs/plugin-vue');
       plugins.push(vuePlugin());
-      const { vueDocgen } = await import('./plugins/vue-docgen');
-      plugins.push(vueDocgen(3));
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
         throw new Error(`
           @storybook/builder-vite requires @vitejs/plugin-vue to be installed when using @storybook/vue3.
           Please install it and start storybook again.
         `);
+      }
+      throw err;
+    }
+
+    try {
+      const { vueDocgen } = await import('./plugins/vue-docgen');
+      plugins.push(vueDocgen(3);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
+        throw new Error(
+          '@storybook/builder-vite requires vue-docgen-api to be installed ' +
+            'when using @storybook/vue3.' +
+            '  Please install it and start storybook again.'
+        );
       }
       throw err;
     }

--- a/packages/builder-vite/yarn.lock
+++ b/packages/builder-vite/yarn.lock
@@ -1985,12 +1985,15 @@ __metadata:
     "@sveltejs/vite-plugin-svelte": ^1.0.0
     "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
+    vue-docgen-api: ^4.40.0
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
       optional: true
     "@sveltejs/vite-plugin-svelte":
       optional: true
     "@vitejs/plugin-vue":
+      optional: true
+    vue-docgen-api:
       optional: true
   languageName: unknown
   linkType: soft

--- a/packages/builder-vite/yarn.lock
+++ b/packages/builder-vite/yarn.lock
@@ -1982,9 +1982,15 @@ __metadata:
     vue-template-compiler: ^2.7.10
   peerDependencies:
     "@storybook/mdx2-csf": ^0.0.3
+    "@sveltejs/vite-plugin-svelte": ^1.0.0
+    "@vitejs/plugin-vue": ^3.0.0
     vite: ">= 3.0.0"
   peerDependenciesMeta:
     "@storybook/mdx2-csf":
+      optional: true
+    "@sveltejs/vite-plugin-svelte":
+      optional: true
+    "@vitejs/plugin-vue":
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Resolves missing peer dependency errors when using Yarn PnP, e.g.

```
ERR! Error: @storybook/builder-vite requires @vitejs/plugin-vue to be installed when using @storybook/vue or @storybook/vue3.  Please install it and start storybook again.
```