### PR TITLE
Re-add typescript check when adding react-docgen-typescript plugin

### DIFF
--- a/packages/builder-vite/vite-config.ts
+++ b/packages/builder-vite/vite-config.ts
@@ -218,7 +218,16 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
       {} as TypescriptConfig
     );
 
-    if (reactDocgenOption === 'react-docgen-typescript') {
+    let typescriptPresent;
+
+    try {
+      require.resolve('typescript');
+      typescriptPresent = true;
+    } catch (e) {
+      typescriptPresent = false;
+    }
+
+    if (reactDocgenOption === 'react-docgen-typescript' && typescriptPresent) {
       plugins.push(
         require('@joshwooding/vite-plugin-react-docgen-typescript')({
           ...reactDocgenTypescriptOptions,


### PR DESCRIPTION
A hybrid of https://github.com/storybookjs/builder-vite/pull/460 and https://github.com/storybookjs/builder-vite/pull/313.

I believe this approach matches how storybook works with webpack.