### PR TITLE
Fix bail not being defined

### DIFF
--- a/packages/builder-vite/index.ts
+++ b/packages/builder-vite/index.ts
@@ -44,8 +44,20 @@ function iframeMiddleware(options: ExtendedOptions, server: ViteDevServer): Requ
   };
 }
 
+let server: ViteDevServer;
+
+export async function bail(e?: Error): Promise<void> {
+  try {
+    return await server.close();
+  } catch (err) {
+    console.warn('unable to close vite server');
+  }
+
+  throw e;
+}
+
 export const start: ViteBuilder['start'] = async ({ startTime, options, router, server: devServer }) => {
-  const server = await createViteServer(options as ExtendedOptions, devServer);
+  server = await createViteServer(options as ExtendedOptions, devServer);
 
   // Just mock this endpoint (which is really Webpack-specific) so we don't get spammed with 404 in browser devtools
   // TODO: we should either show some sort of progress from Vite, or just try to disable the whole Loader in the Manager UI.
@@ -56,16 +68,6 @@ export const start: ViteBuilder['start'] = async ({ startTime, options, router, 
 
   router.use(await iframeMiddleware(options as ExtendedOptions, server));
   router.use(server.middlewares);
-
-  async function bail(e?: Error): Promise<void> {
-    try {
-      return await server.close();
-    } catch (err) {
-      console.warn('unable to close vite server');
-    }
-
-    throw e;
-  }
 
   return {
     bail,


### PR DESCRIPTION
This should fix #485 

Storybook expects bail to be exported from the main index file. The fix is a bit unfortunate since server needs to be hoisted outside of the function.