### PR TITLE
Fix multiple docgen runnign at the same time

### DIFF
--- a/packages/builder-vite/vite-config.ts
+++ b/packages/builder-vite/vite-config.ts
@@ -238,7 +238,7 @@ export async function pluginConfig(options: ExtendedOptions, _type: PluginConfig
     }
 
     // Add react-docgen so long as the option is not false
-    if (typeof reactDocgenOption === 'string') {
+    else if (typeof reactDocgenOption === 'string') {
       const { reactDocgen } = await import('./plugins/react-docgen');
       // Needs to run before the react plugin, so add to the front
       plugins.unshift(


### PR DESCRIPTION
While bumping one project from v0.2.0 to v0.2.1, I experienced errors like:

```txt
> build-storybook -o build-storybook

info @storybook/react v6.5.12
info
info => Cleaning outputDir: C:\dev\monorepo\apps\Front\packages\design-system\build-storybook
info => Loading presets
info => Compiling manager..
info => Manager built (8.96 s)
vite v3.0.9 building for production...
✓ 0 modules transformed.
Could not resolve entry module (index.html).
ERR! Error: Could not resolve entry module (index.html).
ERR!     at error (file:///C:/dev/monorepo/apps/Front/node_modules/rollup/dist/es/shared/rollup.js:1858:30)
ERR!     at ModuleLoader.loadEntryModule (file:///C:/dev/monorepo/apps/Front/node_modules/rollup/dist/es/shared/rollup.js:22352:20)
ERR!     at async Promise.all (index 0)
ERR!  Error: Could not resolve entry module (index.html).
ERR!     at error (file:///C:/dev/monorepo/apps/Front/node_modules/rollup/dist/es/shared/rollup.js:1858:30)
ERR!     at ModuleLoader.loadEntryModule (file:///C:/dev/monorepo/apps/Front/node_modules/rollup/dist/es/shared/rollup.js:22352:20)
ERR!     at async Promise.all (index 0) {
ERR!   code: 'UNRESOLVED_ENTRY'
ERR! }
info => Loading presets
```

By looking into the diff between these two versions I found the following line change: https://github.com/storybookjs/builder-vite/compare/v0.2.0...v0.2.1#diff-1897e37c00f0a892e59db90901f310d352427ba2bd39472789bbd91a1e48c8efR183. Actually while in the past we either push-ed or unshift-ed, we now push and unshift as soon as the docgen has been defined to `react-docgen-typescript`.

The change seem to be related to https://github.com/storybookjs/builder-vite/commit/26e66474b42c6e7e4c98c3cba2a05bfd5805f6eb in which `} else if (reactDocgen) {` got replaced by `if (typeof reactDocgenOption === 'string') {`.

I locally changed the if by else if and dropped the error on my local version. But there might be a real need for this if without a else...?