### PR TITLE
Pin version of react-docgen

### DIFF
--- a/examples/lit-ts/yarn.lock
+++ b/examples/lit-ts/yarn.lock
@@ -2622,7 +2622,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -12988,7 +12988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen@npm:^6.0.0-alpha.0":
+"react-docgen@npm:6.0.0-alpha.3":
   version: 6.0.0-alpha.3
   resolution: "react-docgen@npm:6.0.0-alpha.3"
   dependencies:

--- a/examples/preact/yarn.lock
+++ b/examples/preact/yarn.lock
@@ -2645,7 +2645,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -13089,7 +13089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen@npm:^6.0.0-alpha.0":
+"react-docgen@npm:6.0.0-alpha.3":
   version: 6.0.0-alpha.3
   resolution: "react-docgen@npm:6.0.0-alpha.3"
   dependencies:

--- a/examples/react-18/yarn.lock
+++ b/examples/react-18/yarn.lock
@@ -2701,7 +2701,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -13289,6 +13289,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-docgen@npm:6.0.0-alpha.3":
+  version: 6.0.0-alpha.3
+  resolution: "react-docgen@npm:6.0.0-alpha.3"
+  dependencies:
+    "@babel/core": ^7.7.5
+    "@babel/generator": ^7.12.11
+    ast-types: ^0.14.2
+    commander: ^2.19.0
+    doctrine: ^3.0.0
+    estree-to-babel: ^3.1.0
+    neo-async: ^2.6.1
+    node-dir: ^0.1.10
+    resolve: ^1.17.0
+    strip-indent: ^3.0.0
+  bin:
+    react-docgen: bin/react-docgen.js
+  checksum: db4c300910e2ef7b854ccf4f454bd701875b787d0bc0f444f89415223e7c288a5808d6cd0f7ef6346332c9de2d068d648bc801d16b6b07a1699c3e10670c4801
+  languageName: node
+  linkType: hard
+
 "react-docgen@npm:^5.0.0":
   version: 5.4.3
   resolution: "react-docgen@npm:5.4.3"
@@ -13306,26 +13326,6 @@ __metadata:
   bin:
     react-docgen: bin/react-docgen.js
   checksum: cef935ba948195eaeec9126c62f53bc015b9a5ad3a7eeb4a4604668d5b12bd5d0c9058c279eaf33ee6b47f2a24ccf01818b67af64d7f61265c4d3a5aa4ff0a3a
-  languageName: node
-  linkType: hard
-
-"react-docgen@npm:^6.0.0-alpha.0":
-  version: 6.0.0-alpha.3
-  resolution: "react-docgen@npm:6.0.0-alpha.3"
-  dependencies:
-    "@babel/core": ^7.7.5
-    "@babel/generator": ^7.12.11
-    ast-types: ^0.14.2
-    commander: ^2.19.0
-    doctrine: ^3.0.0
-    estree-to-babel: ^3.1.0
-    neo-async: ^2.6.1
-    node-dir: ^0.1.10
-    resolve: ^1.17.0
-    strip-indent: ^3.0.0
-  bin:
-    react-docgen: bin/react-docgen.js
-  checksum: db4c300910e2ef7b854ccf4f454bd701875b787d0bc0f444f89415223e7c288a5808d6cd0f7ef6346332c9de2d068d648bc801d16b6b07a1699c3e10670c4801
   languageName: node
   linkType: hard
 

--- a/examples/react-ts/yarn.lock
+++ b/examples/react-ts/yarn.lock
@@ -2720,7 +2720,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -13373,6 +13373,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-docgen@npm:6.0.0-alpha.3":
+  version: 6.0.0-alpha.3
+  resolution: "react-docgen@npm:6.0.0-alpha.3"
+  dependencies:
+    "@babel/core": ^7.7.5
+    "@babel/generator": ^7.12.11
+    ast-types: ^0.14.2
+    commander: ^2.19.0
+    doctrine: ^3.0.0
+    estree-to-babel: ^3.1.0
+    neo-async: ^2.6.1
+    node-dir: ^0.1.10
+    resolve: ^1.17.0
+    strip-indent: ^3.0.0
+  bin:
+    react-docgen: bin/react-docgen.js
+  checksum: db4c300910e2ef7b854ccf4f454bd701875b787d0bc0f444f89415223e7c288a5808d6cd0f7ef6346332c9de2d068d648bc801d16b6b07a1699c3e10670c4801
+  languageName: node
+  linkType: hard
+
 "react-docgen@npm:^5.0.0":
   version: 5.4.3
   resolution: "react-docgen@npm:5.4.3"
@@ -13390,26 +13410,6 @@ __metadata:
   bin:
     react-docgen: bin/react-docgen.js
   checksum: cef935ba948195eaeec9126c62f53bc015b9a5ad3a7eeb4a4604668d5b12bd5d0c9058c279eaf33ee6b47f2a24ccf01818b67af64d7f61265c4d3a5aa4ff0a3a
-  languageName: node
-  linkType: hard
-
-"react-docgen@npm:^6.0.0-alpha.0":
-  version: 6.0.0-alpha.3
-  resolution: "react-docgen@npm:6.0.0-alpha.3"
-  dependencies:
-    "@babel/core": ^7.7.5
-    "@babel/generator": ^7.12.11
-    ast-types: ^0.14.2
-    commander: ^2.19.0
-    doctrine: ^3.0.0
-    estree-to-babel: ^3.1.0
-    neo-async: ^2.6.1
-    node-dir: ^0.1.10
-    resolve: ^1.17.0
-    strip-indent: ^3.0.0
-  bin:
-    react-docgen: bin/react-docgen.js
-  checksum: db4c300910e2ef7b854ccf4f454bd701875b787d0bc0f444f89415223e7c288a5808d6cd0f7ef6346332c9de2d068d648bc801d16b6b07a1699c3e10670c4801
   languageName: node
   linkType: hard
 

--- a/examples/react/yarn.lock
+++ b/examples/react/yarn.lock
@@ -2726,7 +2726,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -14132,6 +14132,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-docgen@npm:6.0.0-alpha.3":
+  version: 6.0.0-alpha.3
+  resolution: "react-docgen@npm:6.0.0-alpha.3"
+  dependencies:
+    "@babel/core": ^7.7.5
+    "@babel/generator": ^7.12.11
+    ast-types: ^0.14.2
+    commander: ^2.19.0
+    doctrine: ^3.0.0
+    estree-to-babel: ^3.1.0
+    neo-async: ^2.6.1
+    node-dir: ^0.1.10
+    resolve: ^1.17.0
+    strip-indent: ^3.0.0
+  bin:
+    react-docgen: bin/react-docgen.js
+  checksum: db4c300910e2ef7b854ccf4f454bd701875b787d0bc0f444f89415223e7c288a5808d6cd0f7ef6346332c9de2d068d648bc801d16b6b07a1699c3e10670c4801
+  languageName: node
+  linkType: hard
+
 "react-docgen@npm:^5.0.0":
   version: 5.4.3
   resolution: "react-docgen@npm:5.4.3"
@@ -14149,26 +14169,6 @@ __metadata:
   bin:
     react-docgen: bin/react-docgen.js
   checksum: cef935ba948195eaeec9126c62f53bc015b9a5ad3a7eeb4a4604668d5b12bd5d0c9058c279eaf33ee6b47f2a24ccf01818b67af64d7f61265c4d3a5aa4ff0a3a
-  languageName: node
-  linkType: hard
-
-"react-docgen@npm:^6.0.0-alpha.0":
-  version: 6.0.0-alpha.3
-  resolution: "react-docgen@npm:6.0.0-alpha.3"
-  dependencies:
-    "@babel/core": ^7.7.5
-    "@babel/generator": ^7.12.11
-    ast-types: ^0.14.2
-    commander: ^2.19.0
-    doctrine: ^3.0.0
-    estree-to-babel: ^3.1.0
-    neo-async: ^2.6.1
-    node-dir: ^0.1.10
-    resolve: ^1.17.0
-    strip-indent: ^3.0.0
-  bin:
-    react-docgen: bin/react-docgen.js
-  checksum: db4c300910e2ef7b854ccf4f454bd701875b787d0bc0f444f89415223e7c288a5808d6cd0f7ef6346332c9de2d068d648bc801d16b6b07a1699c3e10670c4801
   languageName: node
   linkType: hard
 

--- a/examples/svelte/yarn.lock
+++ b/examples/svelte/yarn.lock
@@ -2631,7 +2631,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -13293,7 +13293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen@npm:^6.0.0-alpha.0":
+"react-docgen@npm:6.0.0-alpha.3":
   version: 6.0.0-alpha.3
   resolution: "react-docgen@npm:6.0.0-alpha.3"
   dependencies:

--- a/examples/vue2.6/yarn.lock
+++ b/examples/vue2.6/yarn.lock
@@ -2719,7 +2719,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -14846,7 +14846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen@npm:^6.0.0-alpha.0":
+"react-docgen@npm:6.0.0-alpha.3":
   version: 6.0.0-alpha.3
   resolution: "react-docgen@npm:6.0.0-alpha.3"
   dependencies:

--- a/examples/vue2.7/yarn.lock
+++ b/examples/vue2.7/yarn.lock
@@ -2719,7 +2719,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -14678,7 +14678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen@npm:^6.0.0-alpha.0":
+"react-docgen@npm:6.0.0-alpha.3":
   version: 6.0.0-alpha.3
   resolution: "react-docgen@npm:6.0.0-alpha.3"
   dependencies:

--- a/examples/vue3/yarn.lock
+++ b/examples/vue3/yarn.lock
@@ -2884,7 +2884,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -15317,7 +15317,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen@npm:^6.0.0-alpha.0":
+"react-docgen@npm:6.0.0-alpha.3":
   version: 6.0.0-alpha.3
   resolution: "react-docgen@npm:6.0.0-alpha.3"
   dependencies:

--- a/examples/workspaces/yarn.lock
+++ b/examples/workspaces/yarn.lock
@@ -2701,7 +2701,7 @@ __metadata:
     glob: ^7.2.0
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     sveltedoc-parser: ^4.2.1
   peerDependencies:
@@ -13294,6 +13294,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-docgen@npm:6.0.0-alpha.3":
+  version: 6.0.0-alpha.3
+  resolution: "react-docgen@npm:6.0.0-alpha.3"
+  dependencies:
+    "@babel/core": ^7.7.5
+    "@babel/generator": ^7.12.11
+    ast-types: ^0.14.2
+    commander: ^2.19.0
+    doctrine: ^3.0.0
+    estree-to-babel: ^3.1.0
+    neo-async: ^2.6.1
+    node-dir: ^0.1.10
+    resolve: ^1.17.0
+    strip-indent: ^3.0.0
+  bin:
+    react-docgen: bin/react-docgen.js
+  checksum: db4c300910e2ef7b854ccf4f454bd701875b787d0bc0f444f89415223e7c288a5808d6cd0f7ef6346332c9de2d068d648bc801d16b6b07a1699c3e10670c4801
+  languageName: node
+  linkType: hard
+
 "react-docgen@npm:^5.0.0":
   version: 5.4.3
   resolution: "react-docgen@npm:5.4.3"
@@ -13311,26 +13331,6 @@ __metadata:
   bin:
     react-docgen: bin/react-docgen.js
   checksum: cef935ba948195eaeec9126c62f53bc015b9a5ad3a7eeb4a4604668d5b12bd5d0c9058c279eaf33ee6b47f2a24ccf01818b67af64d7f61265c4d3a5aa4ff0a3a
-  languageName: node
-  linkType: hard
-
-"react-docgen@npm:^6.0.0-alpha.0":
-  version: 6.0.0-alpha.3
-  resolution: "react-docgen@npm:6.0.0-alpha.3"
-  dependencies:
-    "@babel/core": ^7.7.5
-    "@babel/generator": ^7.12.11
-    ast-types: ^0.14.2
-    commander: ^2.19.0
-    doctrine: ^3.0.0
-    estree-to-babel: ^3.1.0
-    neo-async: ^2.6.1
-    node-dir: ^0.1.10
-    resolve: ^1.17.0
-    strip-indent: ^3.0.0
-  bin:
-    react-docgen: bin/react-docgen.js
-  checksum: db4c300910e2ef7b854ccf4f454bd701875b787d0bc0f444f89415223e7c288a5808d6cd0f7ef6346332c9de2d068d648bc801d16b6b07a1699c3e10670c4801
   languageName: node
   linkType: hard
 

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -36,7 +36,7 @@
     "glob": "^7.2.0",
     "glob-promise": "^4.2.0",
     "magic-string": "^0.26.1",
-    "react-docgen": "^6.0.0-alpha.0",
+    "react-docgen": "6.0.0-alpha.3",
     "slash": "^3.0.0",
     "sveltedoc-parser": "^4.2.1"
   },

--- a/packages/builder-vite/yarn.lock
+++ b/packages/builder-vite/yarn.lock
@@ -1909,7 +1909,7 @@ __metadata:
     glob-promise: ^4.2.0
     magic-string: ^0.26.1
     prettier: ^2.7.1
-    react-docgen: ^6.0.0-alpha.0
+    react-docgen: 6.0.0-alpha.3
     slash: ^3.0.0
     svelte: ^3.50.1
     sveltedoc-parser: ^4.2.1
@@ -9184,7 +9184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen@npm:^6.0.0-alpha.0":
+"react-docgen@npm:6.0.0-alpha.3":
   version: 6.0.0-alpha.3
   resolution: "react-docgen@npm:6.0.0-alpha.3"
   dependencies:


### PR DESCRIPTION
Fixes https://github.com/storybookjs/builder-vite/issues/530

The latest version of react-docgen has gone to ESM only, and made some other changes which break our usage.  This pins the version being used to a known-good version, which is safer during alphas anyway.