### PR TITLE
Inject mdx compiler for mdx1

### DIFF
--- a/examples/lit-ts/.storybook/main.cjs
+++ b/examples/lit-ts/.storybook/main.cjs
@@ -18,6 +18,16 @@ module.exports = {
     return mergeConfig(config, {
       // prettier-ignore
       plugins: [postcssLit({ include: ['**/*.scss', '**/*.scss\?*'] })],
+      // because rollup does not respect NODE_PATH, and we have a funky example setup that needs it
+      build: {
+        rollupOptions: {
+          plugins: {
+            resolveId: function (code) {
+              if (code === 'react') return require.resolve('react');
+            },
+          },
+        },
+      },
     });
   },
 };

--- a/examples/lit-ts/.storybook/main.cjs
+++ b/examples/lit-ts/.storybook/main.cjs
@@ -1,5 +1,6 @@
 const { mergeConfig } = require('vite');
 const postcssLit = require('rollup-plugin-postcss-lit');
+const slash = require('slash');
 
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -23,7 +24,7 @@ module.exports = {
         rollupOptions: {
           plugins: {
             resolveId: function (code) {
-              if (code === 'react') return require.resolve('react');
+              if (code === 'react') return slash(require.resolve('react'));
             },
           },
         },

--- a/examples/lit-ts/.storybook/main.cjs
+++ b/examples/lit-ts/.storybook/main.cjs
@@ -1,6 +1,6 @@
+const path = require('node:path');
 const { mergeConfig } = require('vite');
 const postcssLit = require('rollup-plugin-postcss-lit');
-const slash = require('slash');
 
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -24,7 +24,7 @@ module.exports = {
         rollupOptions: {
           plugins: {
             resolveId: function (code) {
-              if (code === 'react') return slash(require.resolve('react'));
+              if (code === 'react') return path.resolve(require.resolve('react'));
             },
           },
         },

--- a/examples/lit-ts/yarn.lock
+++ b/examples/lit-ts/yarn.lock
@@ -2732,7 +2732,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3220,6 +3220,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3236,16 +3246,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/examples/preact/.storybook/main.cjs
+++ b/examples/preact/.storybook/main.cjs
@@ -1,3 +1,5 @@
+const slash = require('slash');
+
 module.exports = {
   framework: '@storybook/preact',
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -12,8 +14,8 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return require.resolve('react');
-          if (code === 'preact/compat') return require.resolve('preact/compat');
+          if (code === 'react') return slash(require.resolve('react'));
+          if (code === 'preact/compat') return slash(require.resolve('preact/compat'));
         },
       },
     };

--- a/examples/preact/.storybook/main.cjs
+++ b/examples/preact/.storybook/main.cjs
@@ -1,4 +1,4 @@
-const slash = require('slash');
+const path = require('node:path');
 
 module.exports = {
   framework: '@storybook/preact',
@@ -14,8 +14,8 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return slash(require.resolve('react'));
-          if (code === 'preact/compat') return slash(require.resolve('preact/compat'));
+          if (code === 'react') return path.resolve(require.resolve('react'));
+          if (code === 'preact/compat') return path.resolve(require.resolve('preact/compat'));
         },
       },
     };

--- a/examples/preact/.storybook/main.cjs
+++ b/examples/preact/.storybook/main.cjs
@@ -7,4 +7,16 @@ module.exports = {
     // we don't want to muck up the data when we're working on the builder
     disableTelemetry: true,
   },
+  async viteFinal(config) {
+    // because rollup does not respect NODE_PATH, and we have a funky example setup that needs it
+    config.build.rollupOptions = {
+      plugins: {
+        resolveId: function (code) {
+          if (code === 'react') return require.resolve('react');
+          if (code === 'preact/compat') return require.resolve('preact/compat');
+        },
+      },
+    };
+    return config;
+  },
 };

--- a/examples/preact/yarn.lock
+++ b/examples/preact/yarn.lock
@@ -2755,7 +2755,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3243,6 +3243,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3259,16 +3269,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/examples/react-18/.storybook/main.cjs
+++ b/examples/react-18/.storybook/main.cjs
@@ -1,4 +1,4 @@
-const slash = require('slash');
+const path = require('node:path');
 
 module.exports = {
   framework: '@storybook/react',
@@ -17,7 +17,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code, id) {
-          if (code === 'react') return slash(require.resolve('react'));
+          if (code === 'react') return path.resolve(require.resolve('react'));
         },
       },
     };

--- a/examples/react-18/.storybook/main.cjs
+++ b/examples/react-18/.storybook/main.cjs
@@ -1,3 +1,5 @@
+const slash = require('slash');
+
 module.exports = {
   framework: '@storybook/react',
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -15,7 +17,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code, id) {
-          if (code === 'react') return 'node_modules/react/index.js';
+          if (code === 'react') return slash(require.resolve('react'));
         },
       },
     };

--- a/examples/react-18/.storybook/main.cjs
+++ b/examples/react-18/.storybook/main.cjs
@@ -10,8 +10,15 @@ module.exports = {
   features: {
     storyStoreV7: true,
   },
-  async viteFinal(config, { configType }) {
-    // customize the Vite config here
+  async viteFinal(config) {
+    // because rollup does not respect NODE_PATH
+    config.build.rollupOptions = {
+      plugins: {
+        resolveId: function (code, id) {
+          if (code === 'react') return 'node_modules/react/index.js';
+        },
+      },
+    };
     return config;
   },
 };

--- a/examples/react-18/yarn.lock
+++ b/examples/react-18/yarn.lock
@@ -2802,7 +2802,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3290,6 +3290,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3306,16 +3316,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/examples/react-ts/.storybook/main.cjs
+++ b/examples/react-ts/.storybook/main.cjs
@@ -1,3 +1,5 @@
+const slash = require('slash');
+
 module.exports = {
   framework: '@storybook/react',
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -15,7 +17,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return require.resolve('react');
+          if (code === 'react') return slash(require.resolve('react'));
         },
       },
     };

--- a/examples/react-ts/.storybook/main.cjs
+++ b/examples/react-ts/.storybook/main.cjs
@@ -10,8 +10,15 @@ module.exports = {
   features: {
     storyStoreV7: true,
   },
-  async viteFinal(config, { configType }) {
-    // customize the Vite config here
+  async viteFinal(config) {
+    // because rollup does not respect NODE_PATH, and we have a funky example setup that needs it
+    config.build.rollupOptions = {
+      plugins: {
+        resolveId: function (code) {
+          if (code === 'react') return require.resolve('react');
+        },
+      },
+    };
     return config;
   },
 };

--- a/examples/react-ts/.storybook/main.cjs
+++ b/examples/react-ts/.storybook/main.cjs
@@ -1,4 +1,4 @@
-const slash = require('slash');
+const path = require('node:path');
 
 module.exports = {
   framework: '@storybook/react',
@@ -17,7 +17,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return slash(require.resolve('react'));
+          if (code === 'react') return path.resolve(require.resolve('react'));
         },
       },
     };

--- a/examples/react-ts/yarn.lock
+++ b/examples/react-ts/yarn.lock
@@ -2990,7 +2990,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3478,6 +3478,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3494,16 +3504,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/examples/react/.storybook/main.cjs
+++ b/examples/react/.storybook/main.cjs
@@ -1,3 +1,5 @@
+const slash = require('slash');
+
 module.exports = {
   framework: '@storybook/react',
   stories: ['../stories/**/*stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -16,7 +18,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return require.resolve('react');
+          if (code === 'react') return slash(require.resolve('react'));
         },
       },
     };

--- a/examples/react/.storybook/main.cjs
+++ b/examples/react/.storybook/main.cjs
@@ -12,6 +12,14 @@ module.exports = {
     previewMdx2: true,
   },
   async viteFinal(config) {
+    // because rollup does not respect NODE_PATH, and we have a funky example setup that needs it
+    config.build.rollupOptions = {
+      plugins: {
+        resolveId: function (code) {
+          if (code === 'react') return require.resolve('react');
+        },
+      },
+    };
     return config;
   },
 };

--- a/examples/react/.storybook/main.cjs
+++ b/examples/react/.storybook/main.cjs
@@ -1,4 +1,4 @@
-const slash = require('slash');
+const path = require('node:path');
 
 module.exports = {
   framework: '@storybook/react',
@@ -18,7 +18,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return slash(require.resolve('react'));
+          if (code === 'react') return path.resolve(require.resolve('react'));
         },
       },
     };

--- a/examples/react/yarn.lock
+++ b/examples/react/yarn.lock
@@ -2824,7 +2824,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3312,6 +3312,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3328,16 +3338,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/examples/svelte/.storybook/main.cjs
+++ b/examples/svelte/.storybook/main.cjs
@@ -1,4 +1,4 @@
-const preprocess = require('svelte-preprocess');
+const slash = require('slash');
 
 module.exports = {
   framework: '@storybook/svelte',
@@ -18,7 +18,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return require.resolve('react');
+          if (code === 'react') return slash(require.resolve('react'));
         },
       },
     };

--- a/examples/svelte/.storybook/main.cjs
+++ b/examples/svelte/.storybook/main.cjs
@@ -1,4 +1,4 @@
-const slash = require('slash');
+const path = require('node:path');
 
 module.exports = {
   framework: '@storybook/svelte',
@@ -18,7 +18,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return slash(require.resolve('react'));
+          if (code === 'react') return path.resolve(require.resolve('react'));
         },
       },
     };

--- a/examples/svelte/.storybook/main.cjs
+++ b/examples/svelte/.storybook/main.cjs
@@ -13,8 +13,15 @@ module.exports = {
     // On-demand store does not work for .svelte stories, only CSF.
     storyStoreV7: false,
   },
-  async viteFinal(config, { configType }) {
-    // customize the Vite config here
+  async viteFinal(config) {
+    // because rollup does not respect NODE_PATH, and we have a funky example setup that needs it
+    config.build.rollupOptions = {
+      plugins: {
+        resolveId: function (code) {
+          if (code === 'react') return require.resolve('react');
+        },
+      },
+    };
     return config;
   },
   // @ts-ignore

--- a/examples/svelte/yarn.lock
+++ b/examples/svelte/yarn.lock
@@ -2741,7 +2741,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3229,6 +3229,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3245,16 +3255,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/examples/vue2.6/.storybook/main.cjs
+++ b/examples/vue2.6/.storybook/main.cjs
@@ -30,6 +30,16 @@ module.exports = {
           '@storybook/addon-outline/preview.js',
         ],
       },
+      // because rollup does not respect NODE_PATH, and we have a funky example setup that needs it
+      build: {
+        rollupOptions: {
+          plugins: {
+            resolveId: function (code) {
+              if (code === 'react') return require.resolve('react');
+            },
+          },
+        },
+      },
     });
   },
 };

--- a/examples/vue2.6/.storybook/main.cjs
+++ b/examples/vue2.6/.storybook/main.cjs
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 const { mergeConfig } = require('vite');
-const slash = require('slash');
+const path = require('node:path');
 
 module.exports = {
   framework: '@storybook/vue',
@@ -36,7 +36,7 @@ module.exports = {
         rollupOptions: {
           plugins: {
             resolveId: function (code) {
-              if (code === 'react') return slash(require.resolve('react'));
+              if (code === 'react') return path.resolve(require.resolve('react'));
             },
           },
         },

--- a/examples/vue2.6/.storybook/main.cjs
+++ b/examples/vue2.6/.storybook/main.cjs
@@ -1,5 +1,6 @@
 const { resolve } = require('path');
 const { mergeConfig } = require('vite');
+const slash = require('slash');
 
 module.exports = {
   framework: '@storybook/vue',
@@ -35,7 +36,7 @@ module.exports = {
         rollupOptions: {
           plugins: {
             resolveId: function (code) {
-              if (code === 'react') return require.resolve('react');
+              if (code === 'react') return slash(require.resolve('react'));
             },
           },
         },

--- a/examples/vue2.6/yarn.lock
+++ b/examples/vue2.6/yarn.lock
@@ -2689,7 +2689,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3211,6 +3211,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3227,16 +3237,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/examples/vue2.7/.storybook/main.cjs
+++ b/examples/vue2.7/.storybook/main.cjs
@@ -30,6 +30,16 @@ module.exports = {
           '@storybook/addon-outline/preview.js',
         ],
       },
+      // because rollup does not respect NODE_PATH, and we have a funky example setup that needs it
+      build: {
+        rollupOptions: {
+          plugins: {
+            resolveId: function (code) {
+              if (code === 'react') return require.resolve('react');
+            },
+          },
+        },
+      },
     });
   },
 };

--- a/examples/vue2.7/.storybook/main.cjs
+++ b/examples/vue2.7/.storybook/main.cjs
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 const { mergeConfig } = require('vite');
-const slash = require('slash');
+const path = require('node:path');
 
 module.exports = {
   framework: '@storybook/vue',
@@ -36,7 +36,7 @@ module.exports = {
         rollupOptions: {
           plugins: {
             resolveId: function (code) {
-              if (code === 'react') return slash(require.resolve('react'));
+              if (code === 'react') return path.resolve(require.resolve('react'));
             },
           },
         },

--- a/examples/vue2.7/.storybook/main.cjs
+++ b/examples/vue2.7/.storybook/main.cjs
@@ -1,5 +1,6 @@
 const { resolve } = require('path');
 const { mergeConfig } = require('vite');
+const slash = require('slash');
 
 module.exports = {
   framework: '@storybook/vue',
@@ -35,7 +36,7 @@ module.exports = {
         rollupOptions: {
           plugins: {
             resolveId: function (code) {
-              if (code === 'react') return require.resolve('react');
+              if (code === 'react') return slash(require.resolve('react'));
             },
           },
         },

--- a/examples/vue2.7/yarn.lock
+++ b/examples/vue2.7/yarn.lock
@@ -2679,7 +2679,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3201,6 +3201,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3217,16 +3227,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/examples/vue3/.storybook/main.cjs
+++ b/examples/vue3/.storybook/main.cjs
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 const { mergeConfig } = require('vite');
-const slash = require('slash');
+const path = require('node:path');
 
 module.exports = {
   framework: '@storybook/vue3',
@@ -25,7 +25,7 @@ module.exports = {
         rollupOptions: {
           plugins: {
             resolveId: function (code) {
-              if (code === 'react') return slash(require.resolve('react'));
+              if (code === 'react') return path.resolve(require.resolve('react'));
             },
           },
         },

--- a/examples/vue3/.storybook/main.cjs
+++ b/examples/vue3/.storybook/main.cjs
@@ -1,5 +1,6 @@
 const { resolve } = require('path');
 const { mergeConfig } = require('vite');
+const slash = require('slash');
 
 module.exports = {
   framework: '@storybook/vue3',
@@ -24,7 +25,7 @@ module.exports = {
         rollupOptions: {
           plugins: {
             resolveId: function (code) {
-              if (code === 'react') return require.resolve('react');
+              if (code === 'react') return slash(require.resolve('react'));
             },
           },
         },

--- a/examples/vue3/.storybook/main.cjs
+++ b/examples/vue3/.storybook/main.cjs
@@ -19,6 +19,16 @@ module.exports = {
       resolve: {
         alias: [{ find: '@assets', replacement: resolve(__dirname, '..', 'stories', 'assets') }],
       },
+      // because rollup does not respect NODE_PATH, and we have a funky example setup that needs it
+      build: {
+        rollupOptions: {
+          plugins: {
+            resolveId: function (code) {
+              if (code === 'react') return require.resolve('react');
+            },
+          },
+        },
+      },
     });
   },
 };

--- a/examples/vue3/yarn.lock
+++ b/examples/vue3/yarn.lock
@@ -2959,7 +2959,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3639,6 +3639,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3655,16 +3665,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/examples/workspaces/packages/catalog/.storybook/main.cjs
+++ b/examples/workspaces/packages/catalog/.storybook/main.cjs
@@ -1,4 +1,4 @@
-const slash = require('slash');
+const path = require('node:path');
 
 module.exports = {
   framework: '@storybook/react',
@@ -20,7 +20,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return slash(require.resolve('react'));
+          if (code === 'react') return path.resolve(require.resolve('react'));
         },
       },
     };

--- a/examples/workspaces/packages/catalog/.storybook/main.cjs
+++ b/examples/workspaces/packages/catalog/.storybook/main.cjs
@@ -1,3 +1,5 @@
+const slash = require('slash');
+
 module.exports = {
   framework: '@storybook/react',
   stories: [
@@ -18,7 +20,7 @@ module.exports = {
     config.build.rollupOptions = {
       plugins: {
         resolveId: function (code) {
-          if (code === 'react') return require.resolve('react');
+          if (code === 'react') return slash(require.resolve('react'));
         },
       },
     };

--- a/examples/workspaces/packages/catalog/.storybook/main.cjs
+++ b/examples/workspaces/packages/catalog/.storybook/main.cjs
@@ -13,8 +13,15 @@ module.exports = {
   features: {
     storyStoreV7: true,
   },
-  async viteFinal(config, { configType }) {
-    // customize the Vite config here
+  async viteFinal(config) {
+    // because rollup does not respect NODE_PATH, and we have a funky example setup that needs it
+    config.build.rollupOptions = {
+      plugins: {
+        resolveId: function (code) {
+          if (code === 'react') return require.resolve('react');
+        },
+      },
+    };
     return config;
   },
 };

--- a/examples/workspaces/yarn.lock
+++ b/examples/workspaces/yarn.lock
@@ -2824,7 +2824,7 @@ __metadata:
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": 0.2.1
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
     "@storybook/source-loader": ^6.4.3
@@ -3312,6 +3312,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
+  version: 1.0.0-next.0
+  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
+  dependencies:
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
+  languageName: node
+  linkType: hard
+
 "@storybook/mdx1-csf@npm:^0.0.1":
   version: 0.0.1
   resolution: "@storybook/mdx1-csf@npm:0.0.1"
@@ -3328,16 +3338,6 @@ __metadata:
     prettier: ">=2.2.1 <=2.3.0"
     ts-dedent: ^2.0.0
   checksum: 34f952f4d00d4fbf680aadea53ca0d9b02b10c94ea492a47a6df916474ea1e36d08eece70ffaba760a4cdf6f634a8684360dc49355cf8a1461050b8a470d2666
-  languageName: node
-  linkType: hard
-
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
-  version: 1.0.0-next.0
-  resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
-  dependencies:
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-  checksum: 4524619df9f412d93e37df05bcdcef40bf3337b8de181a5bcc7ab2051f7afc96e8b9bf4bef8e078d470df81cc4d9d01315cd840e358ca3bfb1102efd595720cd
   languageName: node
   linkType: hard
 

--- a/packages/builder-vite/package.json
+++ b/packages/builder-vite/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@joshwooding/vite-plugin-react-docgen-typescript": "0.2.1",
     "@storybook/core-common": "^6.4.3",
-    "@storybook/mdx1-csf": "^1.0.0-next.0",
+    "@storybook/mdx1-csf": "1.0.0-next.0",
     "@storybook/node-logger": "^6.4.3",
     "@storybook/semver": "^7.3.2",
     "@storybook/source-loader": "^6.4.3",

--- a/packages/builder-vite/yarn.lock
+++ b/packages/builder-vite/yarn.lock
@@ -1983,7 +1983,7 @@ __metadata:
     "@storybook/addon-svelte-csf": ^2.0.7
     "@storybook/client-api": ^6.5.12
     "@storybook/core-common": ^6.4.3
-    "@storybook/mdx1-csf": ^1.0.0-next.0
+    "@storybook/mdx1-csf": 1.0.0-next.0
     "@storybook/mdx2-csf": next
     "@storybook/node-logger": ^6.4.3
     "@storybook/semver": ^7.3.2
@@ -2192,7 +2192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/mdx1-csf@npm:^1.0.0-next.0":
+"@storybook/mdx1-csf@npm:1.0.0-next.0":
   version: 1.0.0-next.0
   resolution: "@storybook/mdx1-csf@npm:1.0.0-next.0"
   dependencies:


### PR DESCRIPTION
fixes https://github.com/storybookjs/builder-vite/issues/557

I found that mdx was not working correctly here, and @valentinpalkovic realized my fallback in Storybook 7 wasn't either (https://github.com/storybookjs/storybook/pull/20823).  It was because we used to inject the mdx compiler into the source code that we get back from the `@storybook/mdx1-csf` compiler, but we lost that in https://github.com/storybookjs/builder-vite/pull/548/files#diff-f2dfc4dfa9074d77a728a88e6629a1d66be8a0765cab8562526cd00fbae910e5L6.  This re-introduces it, with a bit better of a guarantee that the correct version is going to be loaded, by starting from inside `@storybook/mdx1-csf`.

I've also pinned mdx1-csf here, in case the import is moved from the loader to the compiler, as @shilman has suggested doing.  We'll need to adjust this if that happens.